### PR TITLE
fix: use FileEventStore NuGet package

### DIFF
--- a/ChoreMonkey.Core/ChoreMonkey.Core.csproj
+++ b/ChoreMonkey.Core/ChoreMonkey.Core.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\FileBasedEventStore\src\FileEventStore\FileEventStore.csproj" />
+    <PackageReference Include="FileEventStore" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChoreMonkey.Events/ChoreMonkey.Events.csproj
+++ b/ChoreMonkey.Events/ChoreMonkey.Events.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\FileBasedEventStore\src\FileEventStore\FileEventStore.csproj" />
+    <PackageReference Include="FileEventStore" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github" value="https://nuget.pkg.github.com/jocelynenglund/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <github>
+      <add key="Username" value="jocelynenglund" />
+      <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+    </github>
+  </packageSourceCredentials>
+</configuration>


### PR DESCRIPTION
Switches from local project reference to NuGet package from GitHub Packages.

- Adds nuget.config for GitHub Packages feed
- Updates ChoreMonkey.Events and ChoreMonkey.Core to use PackageReference