### PR TITLE
fix: configurable event store path

### DIFF
--- a/ChoreMonkey.Core/Initialization.cs
+++ b/ChoreMonkey.Core/Initialization.cs
@@ -22,7 +22,10 @@ public static class Initialization
 {
     public static IServiceCollection AddChoreMonkeyCore(this IServiceCollection services)
     {
-        return services.AddFileEventStore(Path.Combine(Directory.GetCurrentDirectory(), "data"))
+        // Use environment variable for data path, default to ./data for local dev
+        var dataPath = Environment.GetEnvironmentVariable("EVENTSTORE_PATH") 
+            ?? Path.Combine(Directory.GetCurrentDirectory(), "data");
+        return services.AddFileEventStore(dataPath)
             .InstallFeatures();
 
     }


### PR DESCRIPTION
Allows setting EVENTSTORE_PATH env var to persist data outside deployment folder.