### PR TITLE
feat: Overdue chores query (grouped by member)

### DIFF
--- a/ChoreMonkey.Core/Feature/OverdueChores/Handler.cs
+++ b/ChoreMonkey.Core/Feature/OverdueChores/Handler.cs
@@ -1,0 +1,194 @@
+using ChoreMonkey.Core.Domain;
+using ChoreMonkey.Events;
+using FileEventStore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace ChoreMonkey.Core.Feature.OverdueChores;
+
+public record GetOverdueQuery(Guid HouseholdId);
+
+public record OverdueChoreDto(
+    Guid ChoreId,
+    string DisplayName,
+    int OverdueDays,
+    DateTime? LastCompleted);
+
+public record MemberOverdueDto(
+    Guid MemberId,
+    string Nickname,
+    int OverdueCount,
+    List<OverdueChoreDto> Chores);
+
+public record GetOverdueResponse(List<MemberOverdueDto> MemberOverdue);
+
+internal class Handler(IEventStore store)
+{
+    public async Task<GetOverdueResponse> HandleAsync(GetOverdueQuery request)
+    {
+        var householdStreamId = HouseholdAggregate.StreamId(request.HouseholdId);
+        var choreStreamId = ChoreAggregate.StreamId(request.HouseholdId);
+        
+        var householdEvents = await store.FetchEventsAsync(householdStreamId);
+        var choreEvents = await store.FetchEventsAsync(choreStreamId);
+        
+        var today = DateTime.UtcNow.Date;
+        
+        // Get all members
+        var members = householdEvents.OfType<MemberJoinedHousehold>()
+            .ToDictionary(e => e.MemberId, e => e.Nickname);
+        
+        // Get all chores with frequencies
+        var chores = choreEvents.OfType<ChoreCreated>()
+            .ToDictionary(e => e.ChoreId);
+        
+        // Get latest assignments
+        var assignments = choreEvents.OfType<ChoreAssigned>()
+            .GroupBy(e => e.ChoreId)
+            .ToDictionary(g => g.Key, g => g.Last());
+        
+        // Get completions grouped by chore and member
+        var completions = choreEvents.OfType<ChoreCompleted>()
+            .GroupBy(e => (e.ChoreId, e.CompletedByMemberId))
+            .ToDictionary(
+                g => g.Key, 
+                g => g.OrderByDescending(c => c.CompletedAt).First());
+        
+        var result = new List<MemberOverdueDto>();
+        
+        foreach (var (memberId, nickname) in members)
+        {
+            var overdueChores = new List<OverdueChoreDto>();
+            
+            foreach (var (choreId, chore) in chores)
+            {
+                // Check if this member is assigned to this chore
+                var assignment = assignments.GetValueOrDefault(choreId);
+                var isAssigned = assignment?.AssignToAll == true ||
+                    (assignment?.AssignedToMemberIds?.Contains(memberId) ?? false);
+                
+                if (!isAssigned) continue;
+                
+                // Get this member's last completion
+                var lastCompletion = completions.GetValueOrDefault((choreId, memberId));
+                var lastCompletedAt = lastCompletion?.CompletedAt;
+                
+                // Calculate if overdue
+                var overdueDays = CalculateOverdueDays(chore.Frequency, lastCompletedAt, today);
+                
+                if (overdueDays > 0)
+                {
+                    overdueChores.Add(new OverdueChoreDto(
+                        choreId,
+                        chore.DisplayName,
+                        overdueDays,
+                        lastCompletedAt));
+                }
+            }
+            
+            result.Add(new MemberOverdueDto(
+                memberId,
+                nickname,
+                overdueChores.Count,
+                overdueChores.OrderByDescending(c => c.OverdueDays).ToList()));
+        }
+        
+        // Sort: members with overdue chores first, then by count descending
+        return new GetOverdueResponse(
+            result.OrderByDescending(m => m.OverdueCount > 0)
+                  .ThenByDescending(m => m.OverdueCount)
+                  .ToList());
+    }
+    
+    private static int CalculateOverdueDays(ChoreFrequency? frequency, DateTime? lastCompleted, DateTime today)
+    {
+        if (frequency == null) return 0;
+        
+        return frequency.Type.ToLower() switch
+        {
+            "daily" => CalculateDailyOverdue(lastCompleted, today),
+            "weekly" => CalculateWeeklyOverdue(frequency.Days, lastCompleted, today),
+            "interval" => CalculateIntervalOverdue(frequency.IntervalDays ?? 1, lastCompleted, today),
+            "once" => 0, // One-time chores can't be overdue
+            _ => 0
+        };
+    }
+    
+    private static int CalculateDailyOverdue(DateTime? lastCompleted, DateTime today)
+    {
+        if (lastCompleted == null)
+        {
+            // If never completed, consider it 1 day overdue (should have been done yesterday)
+            return 1;
+        }
+        
+        var lastCompletedDate = lastCompleted.Value.Date;
+        
+        // If completed today, not overdue
+        if (lastCompletedDate >= today) return 0;
+        
+        // If completed yesterday, not overdue (they have today to do it)
+        if (lastCompletedDate >= today.AddDays(-1)) return 0;
+        
+        // Overdue by number of days since it should have been done
+        return (int)(today - lastCompletedDate).TotalDays - 1;
+    }
+    
+    private static int CalculateWeeklyOverdue(string[]? days, DateTime? lastCompleted, DateTime today)
+    {
+        if (days == null || days.Length == 0) return 0;
+        
+        // Find the most recent required day that has passed
+        var requiredDays = days
+            .Select(d => Enum.Parse<DayOfWeek>(d, ignoreCase: true))
+            .ToHashSet();
+        
+        // Look back up to 7 days to find the last required day
+        for (int i = 1; i <= 7; i++)
+        {
+            var checkDate = today.AddDays(-i);
+            if (requiredDays.Contains(checkDate.DayOfWeek))
+            {
+                // This was a required day - was it completed?
+                if (lastCompleted == null || lastCompleted.Value.Date < checkDate)
+                {
+                    return i; // Overdue by this many days
+                }
+                return 0; // Was completed on or after the required day
+            }
+        }
+        
+        return 0;
+    }
+    
+    private static int CalculateIntervalOverdue(int intervalDays, DateTime? lastCompleted, DateTime today)
+    {
+        if (lastCompleted == null)
+        {
+            // If never completed, consider it overdue by the interval
+            return intervalDays;
+        }
+        
+        var daysSinceCompletion = (int)(today - lastCompleted.Value.Date).TotalDays;
+        
+        if (daysSinceCompletion <= intervalDays) return 0;
+        
+        return daysSinceCompletion - intervalDays;
+    }
+}
+
+internal static class OverdueChoresEndpoint
+{
+    public static void Map(this RouteGroupBuilder group)
+    {
+        group.MapGet("households/{householdId:guid}/overdue", async (
+            Guid householdId,
+            Handler handler) =>
+        {
+            var query = new GetOverdueQuery(householdId);
+            var result = await handler.HandleAsync(query);
+            return Results.Ok(result);
+        });
+    }
+}

--- a/ChoreMonkey.Core/Initialization.cs
+++ b/ChoreMonkey.Core/Initialization.cs
@@ -15,6 +15,7 @@ using ChoreMonkey.Core.Feature.ListMembers;
 using ChoreMonkey.Core.Feature.AssignChore;
 using ChoreMonkey.Core.Feature.CompleteChore;
 using ChoreMonkey.Core.Feature.ChoreHistory;
+using ChoreMonkey.Core.Feature.OverdueChores;
 
 namespace ChoreMonkey.Core;
 
@@ -43,6 +44,7 @@ public static class Initialization
         services.AddScoped<Feature.AssignChore.Handler>();
         services.AddScoped<Feature.CompleteChore.Handler>();
         services.AddScoped<Feature.ChoreHistory.Handler>();
+        services.AddScoped<Feature.OverdueChores.Handler>();
         return services;
     }
     public static IEndpointRouteBuilder MapChoreMonkeyEndpoints(this IEndpointRouteBuilder app)
@@ -62,6 +64,7 @@ public static class Initialization
         AssignChoreEndpoint.Map(householdEndpoints);
         CompleteChoreEndpoint.Map(householdEndpoints);
         ChoreHistoryEndpoint.Map(householdEndpoints);
+        OverdueChoresEndpoint.Map(householdEndpoints);
 
         return app;
     }

--- a/ChoreMonkey.IntegrationTests/ChoreCompletionTests.cs
+++ b/ChoreMonkey.IntegrationTests/ChoreCompletionTests.cs
@@ -138,7 +138,7 @@ public class ChoreCompletionTests(ApiFixture fixture)
         Guid ChoreId, 
         string DisplayName, 
         string Description, 
-        Guid? AssignedTo,
+        Guid[]? AssignedTo,
         DateTime? LastCompletedAt,
         Guid? LastCompletedBy);
     private record CompleteChoreResponse(Guid ChoreId, Guid CompletedBy, DateTime CompletedAt);

--- a/ChoreMonkey.IntegrationTests/OverdueChoresTests.cs
+++ b/ChoreMonkey.IntegrationTests/OverdueChoresTests.cs
@@ -1,0 +1,243 @@
+namespace ChoreMonkey.IntegrationTests;
+
+[Collection(nameof(ApiCollection))]
+public class OverdueChoresTests(ApiFixture fixture)
+{
+    private readonly HttpClient _client = fixture.Client;
+
+    [Fact]
+    public async Task DailyChore_NotCompletedYesterday_IsOverdue()
+    {
+        // Arrange
+        var household = await CreateHousehold("Overdue Test Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Lazy Kid");
+        
+        // Add a daily chore
+        var choreRequest = new 
+        { 
+            DisplayName = "Make Bed", 
+            Description = "Every morning",
+            Frequency = new { Type = "daily" }
+        };
+        await _client.PostAsJsonAsync($"/api/households/{household.HouseholdId}/chores", choreRequest);
+        
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>(
+            $"/api/households/{household.HouseholdId}/chores");
+        var choreId = chores!.Chores[0].ChoreId;
+        
+        // Assign to kid
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/assign",
+            new { MemberIds = new[] { kid.MemberId }, AssignToAll = false });
+
+        // Act - Get overdue chores (kid hasn't completed anything)
+        var response = await _client.GetAsync($"/api/households/{household.HouseholdId}/overdue");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var result = await response.Content.ReadFromJsonAsync<GetOverdueResponse>();
+        result!.MemberOverdue.Should().NotBeEmpty();
+        
+        var kidOverdue = result.MemberOverdue.First(m => m.MemberId == kid.MemberId);
+        kidOverdue.OverdueCount.Should().BeGreaterThan(0);
+        kidOverdue.Chores.Should().Contain(c => c.DisplayName == "Make Bed");
+    }
+
+    [Fact]
+    public async Task DailyChore_CompletedToday_NotOverdue()
+    {
+        // Arrange
+        var household = await CreateHousehold("Caught Up Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Good Kid");
+        
+        var choreRequest = new 
+        { 
+            DisplayName = "Brush Teeth", 
+            Description = "Morning routine",
+            Frequency = new { Type = "daily" }
+        };
+        await _client.PostAsJsonAsync($"/api/households/{household.HouseholdId}/chores", choreRequest);
+        
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>(
+            $"/api/households/{household.HouseholdId}/chores");
+        var choreId = chores!.Chores[0].ChoreId;
+        
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/assign",
+            new { MemberIds = new[] { kid.MemberId }, AssignToAll = false });
+
+        // Complete the chore today
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/complete",
+            new { MemberId = kid.MemberId });
+
+        // Act
+        var response = await _client.GetAsync($"/api/households/{household.HouseholdId}/overdue");
+
+        // Assert
+        var result = await response.Content.ReadFromJsonAsync<GetOverdueResponse>();
+        var kidOverdue = result!.MemberOverdue.First(m => m.MemberId == kid.MemberId);
+        kidOverdue.OverdueCount.Should().Be(0);
+        kidOverdue.Chores.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task IntervalChore_PastInterval_IsOverdue()
+    {
+        // Arrange
+        var household = await CreateHousehold("Interval Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Plant Forgetter");
+        
+        var choreRequest = new 
+        { 
+            DisplayName = "Water Plants", 
+            Description = "Every 3 days",
+            Frequency = new { Type = "interval", IntervalDays = 3 }
+        };
+        await _client.PostAsJsonAsync($"/api/households/{household.HouseholdId}/chores", choreRequest);
+        
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>(
+            $"/api/households/{household.HouseholdId}/chores");
+        var choreId = chores!.Chores[0].ChoreId;
+        
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/assign",
+            new { MemberIds = new[] { kid.MemberId }, AssignToAll = false });
+
+        // Complete it 5 days ago (overdue by 2 days)
+        var fiveDaysAgo = DateTime.UtcNow.AddDays(-5);
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/complete",
+            new { MemberId = kid.MemberId, CompletedAt = fiveDaysAgo });
+
+        // Act
+        var response = await _client.GetAsync($"/api/households/{household.HouseholdId}/overdue");
+
+        // Assert
+        var result = await response.Content.ReadFromJsonAsync<GetOverdueResponse>();
+        var kidOverdue = result!.MemberOverdue.First(m => m.MemberId == kid.MemberId);
+        kidOverdue.Chores.Should().Contain(c => c.DisplayName == "Water Plants" && c.OverdueDays >= 2);
+    }
+
+    [Fact]
+    public async Task OnceChore_NeverOverdue()
+    {
+        // Arrange
+        var household = await CreateHousehold("One Time Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Procrastinator");
+        
+        var choreRequest = new 
+        { 
+            DisplayName = "Fix Bike", 
+            Description = "One time task",
+            Frequency = new { Type = "once" }
+        };
+        await _client.PostAsJsonAsync($"/api/households/{household.HouseholdId}/chores", choreRequest);
+        
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>(
+            $"/api/households/{household.HouseholdId}/chores");
+        var choreId = chores!.Chores[0].ChoreId;
+        
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/assign",
+            new { MemberIds = new[] { kid.MemberId }, AssignToAll = false });
+
+        // Act - Never completed, but "once" chores can't be overdue
+        var response = await _client.GetAsync($"/api/households/{household.HouseholdId}/overdue");
+
+        // Assert
+        var result = await response.Content.ReadFromJsonAsync<GetOverdueResponse>();
+        var kidOverdue = result!.MemberOverdue.First(m => m.MemberId == kid.MemberId);
+        kidOverdue.Chores.Should().NotContain(c => c.DisplayName == "Fix Bike");
+    }
+
+    [Fact]
+    public async Task MembersWithNoOverdue_ShowZeroCount()
+    {
+        // Arrange
+        var household = await CreateHousehold("Mixed Family");
+        var invite1 = await GenerateInvite(household.HouseholdId);
+        var goodKid = await JoinHousehold(household.HouseholdId, invite1.InviteId, "Good Kid");
+        var invite2 = await GenerateInvite(household.HouseholdId);
+        var lazyKid = await JoinHousehold(household.HouseholdId, invite2.InviteId, "Lazy Kid");
+        
+        var choreRequest = new 
+        { 
+            DisplayName = "Daily Task", 
+            Description = "Daily",
+            Frequency = new { Type = "daily" }
+        };
+        await _client.PostAsJsonAsync($"/api/households/{household.HouseholdId}/chores", choreRequest);
+        
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>(
+            $"/api/households/{household.HouseholdId}/chores");
+        var choreId = chores!.Chores[0].ChoreId;
+        
+        // Assign to both kids
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/assign",
+            new { MemberIds = new[] { goodKid.MemberId, lazyKid.MemberId }, AssignToAll = false });
+
+        // Good kid completes it
+        await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/complete",
+            new { MemberId = goodKid.MemberId });
+
+        // Act
+        var response = await _client.GetAsync($"/api/households/{household.HouseholdId}/overdue");
+
+        // Assert
+        var result = await response.Content.ReadFromJsonAsync<GetOverdueResponse>();
+        
+        var goodKidOverdue = result!.MemberOverdue.First(m => m.MemberId == goodKid.MemberId);
+        goodKidOverdue.OverdueCount.Should().Be(0);
+        
+        var lazyKidOverdue = result.MemberOverdue.First(m => m.MemberId == lazyKid.MemberId);
+        lazyKidOverdue.OverdueCount.Should().Be(1);
+    }
+
+    #region Helpers
+
+    private async Task<CreateHouseholdResponse> CreateHousehold(string name)
+    {
+        var request = new { Name = name, PinCode = 1234 };
+        var response = await _client.PostAsJsonAsync("/api/households", request);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<CreateHouseholdResponse>())!;
+    }
+
+    private async Task<GenerateInviteResponse> GenerateInvite(Guid householdId)
+    {
+        var response = await _client.PostAsync($"/api/households/{householdId}/invite", null);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GenerateInviteResponse>())!;
+    }
+
+    private async Task<JoinHouseholdResponse> JoinHousehold(Guid householdId, Guid inviteId, string nickname)
+    {
+        var request = new { InviteId = inviteId, Nickname = nickname };
+        var response = await _client.PostAsJsonAsync($"/api/households/{householdId}/join", request);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<JoinHouseholdResponse>())!;
+    }
+
+    #endregion
+
+    #region Response Records
+
+    private record CreateHouseholdResponse(Guid HouseholdId, Guid MemberId, string Name);
+    private record GenerateInviteResponse(Guid HouseholdId, Guid InviteId, string Link);
+    private record JoinHouseholdResponse(Guid MemberId, Guid HouseholdId, string Nickname);
+    private record GetChoresResponse(List<ChoreDto> Chores);
+    private record ChoreDto(Guid ChoreId, string DisplayName);
+    private record GetOverdueResponse(List<MemberOverdueDto> MemberOverdue);
+    private record MemberOverdueDto(Guid MemberId, string Nickname, int OverdueCount, List<OverdueChoreDto> Chores);
+    private record OverdueChoreDto(Guid ChoreId, string DisplayName, int OverdueDays, DateTime? LastCompleted);
+
+    #endregion
+}

--- a/ChoreMonkey.IntegrationTests/Scenarios/FamilyOnboardingTests.cs
+++ b/ChoreMonkey.IntegrationTests/Scenarios/FamilyOnboardingTests.cs
@@ -73,26 +73,26 @@ public class FamilyOnboardingTests(ApiFixture fixture)
         // Assign chores to kids
         await _client.PostAsJsonAsync(
             $"/api/households/{household.HouseholdId}/chores/{cleanRoom.ChoreId}/assign",
-            new { MemberId = emma!.MemberId });
+            new { MemberIds = new[] { emma!.MemberId }, AssignToAll = false });
         await _client.PostAsJsonAsync(
             $"/api/households/{household.HouseholdId}/chores/{doDishes.ChoreId}/assign",
-            new { MemberId = jake!.MemberId });
+            new { MemberIds = new[] { jake!.MemberId }, AssignToAll = false });
         await _client.PostAsJsonAsync(
             $"/api/households/{household.HouseholdId}/chores/{takeTrash.ChoreId}/assign",
-            new { MemberId = emma.MemberId });
+            new { MemberIds = new[] { emma.MemberId }, AssignToAll = false });
 
         // === Step 9: Verify final state ===
         var finalChores = await _client.GetFromJsonAsync<GetChoresResponse>(
             $"/api/households/{household.HouseholdId}/chores");
 
         // Emma has 2 chores
-        finalChores!.Chores.Where(c => c.AssignedTo == emma.MemberId).Should().HaveCount(2);
+        finalChores!.Chores.Where(c => c.AssignedTo?.Contains(emma.MemberId) == true).Should().HaveCount(2);
         
         // Jake has 1 chore
-        finalChores.Chores.Where(c => c.AssignedTo == jake.MemberId).Should().HaveCount(1);
+        finalChores.Chores.Where(c => c.AssignedTo?.Contains(jake.MemberId) == true).Should().HaveCount(1);
         
         // All chores are assigned
-        finalChores.Chores.Should().OnlyContain(c => c.AssignedTo != null);
+        finalChores.Chores.Should().OnlyContain(c => c.AssignedTo != null && c.AssignedTo.Length > 0);
     }
 
     #region Response Records
@@ -103,7 +103,7 @@ public class FamilyOnboardingTests(ApiFixture fixture)
     private record ListMembersResponse(List<MemberDto> Members);
     private record MemberDto(Guid MemberId, string Nickname);
     private record GetChoresResponse(List<ChoreDto> Chores);
-    private record ChoreDto(Guid ChoreId, string DisplayName, string Description, Guid? AssignedTo);
+    private record ChoreDto(Guid ChoreId, string DisplayName, string Description, Guid[]? AssignedTo);
 
     #endregion
 }


### PR DESCRIPTION
Adds a query-based overdue chores feature so parents can see who's behind.

## New Endpoint
`GET /households/{id}/overdue`

## Response
```json
{
  "memberOverdue": [
    {
      "memberId": "...",
      "nickname": "Emma",
      "overdueCount": 3,
      "chores": [
        { "choreId": "...", "displayName": "Make Bed", "overdueDays": 2 }
      ]
    }
  ]
}
```

## Overdue Logic
| Frequency | Overdue when... |
|-----------|-----------------|
| Daily | No completion yesterday |
| Weekly [Mon,Thu] | That day passed without completion |
| Interval (3d) | >3 days since last completion |
| Once | Never overdue |

## Tests
- 5 new integration tests for overdue scenarios
- Fixed existing tests for multi-assignee API (Guid? → Guid[])

## Next: Frontend
Accordion UI grouped by member - ready for implementation!