### PR TITLE
feat: Add PIN confirmation to Remove Member dialog

### DIFF
--- a/nestle-together/public/changelog.json
+++ b/nestle-together/public/changelog.json
@@ -1,6 +1,15 @@
 {
-  "generated": "2026-02-15T15:13:14.029Z",
+  "generated": "2026-02-15T15:26:42.918Z",
   "commits": [
+    {
+      "hash": "57448217d7c9be92307671a5a48a4ea538f6c765",
+      "shortHash": "5744821",
+      "message": "fix: Read householdName from API (not just name)",
+      "date": "2026-02-15",
+      "author": "ItsyBOT",
+      "type": "fix",
+      "displayMessage": "Read householdName from API (not just name)"
+    },
     {
       "hash": "175d4fa3f5d21da72fc0a3da226afc8b4911af8e",
       "shortHash": "175d4fa",
@@ -171,15 +180,6 @@
       "author": "ItsyBOT",
       "type": "refactor",
       "displayMessage": "Extract frontend into vertical feature slices"
-    },
-    {
-      "hash": "d2663454c7274a8c4a3b1f19767bed88ced2bac1",
-      "shortHash": "d266345",
-      "message": "fix: show date instead of time for past day completions",
-      "date": "2026-02-15",
-      "author": "ItsyBOT",
-      "type": "fix",
-      "displayMessage": "Show date instead of time for past day completions"
     }
   ]
 }

--- a/nestle-together/src/features/store.ts
+++ b/nestle-together/src/features/store.ts
@@ -53,7 +53,7 @@ interface AppState {
   generateInvite: (householdId: string) => Promise<Invite | null>;
   changeNickname: (householdId: string, memberId: string, newNickname: string) => Promise<boolean>;
   changeStatus: (householdId: string, memberId: string, status: string) => Promise<boolean>;
-  removeMember: (householdId: string, memberId: string, removedByMemberId: string) => Promise<boolean>;
+  removeMember: (householdId: string, memberId: string, removedByMemberId: string, pinCode?: string) => Promise<boolean>;
   
   // Chores
   getHouseholdChores: (householdId: string) => Promise<Chore[]>;
@@ -226,10 +226,10 @@ export const useAppStore = create<AppState>()(
       changeStatus: (householdId, memberId, status) =>
         membersApi.changeStatus(householdId, memberId, status),
 
-      removeMember: async (householdId, memberId) => {
-        const { currentPinCode } = get();
-        if (!currentPinCode) return false;
-        return membersApi.removeMember(householdId, memberId, parseInt(currentPinCode, 10));
+      removeMember: async (householdId, memberId, _removedByMemberId, pinCode) => {
+        const pin = pinCode || get().currentPinCode;
+        if (!pin) return false;
+        return membersApi.removeMember(householdId, memberId, parseInt(pin, 10));
       },
 
       getHouseholdChores: (householdId) => choresApi.fetchChores(householdId),

--- a/nestle-together/src/pages/HouseholdDashboard.tsx
+++ b/nestle-together/src/pages/HouseholdDashboard.tsx
@@ -306,11 +306,15 @@ export default function HouseholdDashboard() {
                   <div className="absolute -top-1 -right-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     <RemoveMemberDialog
                       member={member}
-                      onRemove={async () => {
+                      onRemove={async (pinCode) => {
                         if (currentMemberId) {
-                          await removeMember(household.id, member.id, currentMemberId);
-                          await fetchHouseholdMembers(household.id);
+                          const success = await removeMember(household.id, member.id, currentMemberId, pinCode);
+                          if (success) {
+                            await fetchHouseholdMembers(household.id);
+                          }
+                          return success;
                         }
+                        return false;
                       }}
                     />
                   </div>


### PR DESCRIPTION
## Changes
- Requires admin PIN entry before removing a member
- Shows error message if PIN is incorrect  
- Clears form on dialog close
- Enter key submits the form

## Testing
1. Open a household as admin
2. Hover over a member (not yourself)
3. Click the remove button
4. Dialog now shows PIN input field
5. Wrong PIN → error message
6. Correct PIN → member removed

Closes: N/A