### PR TITLE
feat: team overview visible to all members (read-only for non-admins)

### DIFF
--- a/ChoreMonkey.Core/Feature/Activity/Queries/TeamOverview/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Activity/Queries/TeamOverview/Handler.cs
@@ -40,17 +40,21 @@ internal class Handler(IEventStore store, ISender mediator)
         var householdEvents = await store.FetchEventsAsync(householdStreamId);
         var choreEvents = await store.FetchEventsAsync(choreStreamId);
         
-        // Verify admin access
+        // Verify household access (admin or member PIN)
         var householdCreated = householdEvents.OfType<HouseholdCreated>().FirstOrDefault();
         if (householdCreated == null) return null;
-        
+
         var adminPinHash = householdEvents.OfType<AdminPinChanged>()
             .OrderByDescending(e => e.TimestampUtc)
             .FirstOrDefault()?.NewPinHash ?? householdCreated.PinHash;
-        
-        if (!PinHasher.VerifyPin(request.PinCode, adminPinHash))
+
+        var isAdmin = PinHasher.VerifyPin(request.PinCode, adminPinHash);
+        if (!isAdmin)
         {
-            return null;
+            var memberPinHash = householdEvents.OfType<MemberPinChanged>()
+                .LastOrDefault()?.NewMemberPinHash ?? householdCreated.MemberPinHash;
+            var isMember = memberPinHash != null && PinHasher.VerifyPin(request.PinCode, memberPinHash);
+            if (!isMember) return null;
         }
         
         var today = DateTime.UtcNow.Date;

--- a/nestle-together/e2e/team.spec.ts
+++ b/nestle-together/e2e/team.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+const uniqueId = () => Math.random().toString(36).substring(7);
+
+const ADMIN_PIN = '1234';
+const MEMBER_PIN = '5678';
+
+async function createHousehold(page: import('@playwright/test').Page) {
+  const householdName = `Team Test ${uniqueId()}`;
+  await page.goto('/');
+  await page.click('text=Create Household');
+  await page.getByLabel(/household name/i).fill(householdName);
+  await page.getByLabel(/your name|nickname/i).first().fill('Admin');
+  await page.getByRole('button', { name: /continue/i }).click();
+  await page.getByLabel(/admin.*pin|pin.*code/i).first().fill(ADMIN_PIN);
+  await page.getByRole('button', { name: /create/i }).click();
+  await page.waitForURL(/\/household\//, { timeout: 45000 });
+  await expect(page.locator('h1')).toContainText(householdName, { timeout: 10000 });
+  return page.url();
+}
+
+async function setMemberPin(page: import('@playwright/test').Page) {
+  // Navigate to Admin → Settings tab to set member PIN
+  await page.getByRole('link', { name: /admin/i }).click();
+  await page.waitForURL(/\/admin/, { timeout: 10000 });
+  await page.getByRole('tab', { name: /settings/i }).click();
+
+  await page.locator('#newMemberPin').fill(MEMBER_PIN);
+  await page.getByRole('button', { name: /set member pin/i }).click();
+  await expect(page.locator('text=/member pin updated/i')).toBeVisible({ timeout: 5000 });
+}
+
+async function navigateToTeamTab(page: import('@playwright/test').Page) {
+  await page.getByRole('link', { name: /team/i }).click();
+  await expect(page.locator('text=Household Overview')).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Team tab — admin view', () => {
+  test('shows Household Overview with reassignment hint', async ({ page }) => {
+    await createHousehold(page);
+    await navigateToTeamTab(page);
+
+    await expect(page.locator('text=Household Overview')).toBeVisible();
+    await expect(page.locator('text=/click the gear icon to reassign/i')).toBeVisible();
+  });
+
+  test('shows gear icon when chore is assigned', async ({ page }) => {
+    await createHousehold(page);
+
+    // Add a chore via Admin → Chores tab
+    await page.getByRole('link', { name: /admin/i }).click();
+    await page.waitForURL(/\/admin/, { timeout: 10000 });
+    await page.getByRole('button', { name: /add chore/i }).click();
+    await page.getByLabel(/name|title/i).fill('Dishes');
+    await page.getByRole('button', { name: /add|create|save/i }).last().click();
+    await expect(page.locator('text=Dishes')).toBeVisible({ timeout: 5000 });
+
+    await navigateToTeamTab(page);
+
+    // Expand admin's accordion entry
+    await page.locator('[data-radix-collection-item]').first().click();
+
+    // Gear icon should be present for assigned chores
+    await expect(page.locator('[title="Edit assignment"]')).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('Team tab — member view', () => {
+  let householdAccessUrl: string;
+
+  test.beforeEach(async ({ page }) => {
+    const dashboardUrl = await createHousehold(page);
+    await setMemberPin(page);
+
+    // Logout and re-access with member PIN
+    householdAccessUrl = dashboardUrl.replace('/household/', '/access/');
+    await page.getByRole('button', { name: /logout|log out/i }).click();
+
+    await page.goto(householdAccessUrl);
+    await page.getByLabel(/pin/i).fill(MEMBER_PIN);
+    await page.getByRole('button', { name: /access|enter|submit/i }).click();
+    await page.waitForURL(/\/household\//, { timeout: 45000 });
+  });
+
+  test('shows Household Overview section', async ({ page }) => {
+    await navigateToTeamTab(page);
+    await expect(page.locator('text=Household Overview')).toBeVisible();
+  });
+
+  test('does not show reassignment hint or gear icons', async ({ page }) => {
+    await navigateToTeamTab(page);
+
+    await expect(page.locator('text=/click the gear icon to reassign/i')).not.toBeVisible();
+    await expect(page.locator('[title="Edit assignment"]')).not.toBeVisible();
+  });
+});

--- a/nestle-together/src/components/TeamOverviewAccordion.tsx
+++ b/nestle-together/src/components/TeamOverviewAccordion.tsx
@@ -41,11 +41,6 @@ export function TeamOverviewAccordion({ householdId, onAssignmentChange, refresh
   const [isSaving, setIsSaving] = useState(false);
   
   const { fetchTeamOverview, members, isAdmin, assignChore } = useAppStore();
-  
-  // Only admins can see team overview
-  if (!isAdmin) {
-    return null;
-  }
 
   const loadTeam = async () => {
     setIsLoading(true);
@@ -142,9 +137,11 @@ export function TeamOverviewAccordion({ householdId, onAssignmentChange, refresh
               </Badge>
             )}
           </h3>
-          <p className="text-sm text-muted-foreground mt-1">
-            Click the gear icon to reassign chores
-          </p>
+          {isAdmin && (
+            <p className="text-sm text-muted-foreground mt-1">
+              Click the gear icon to reassign chores
+            </p>
+          )}
         </div>
         <Accordion type="multiple" className="w-full">
           {teamData.map((member) => (
@@ -218,16 +215,18 @@ export function TeamOverviewAccordion({ householdId, onAssignmentChange, refresh
                               ? '✓ done'
                               : 'pending'}
                           </span>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleEditChore(chore);
-                            }}
-                            className="p-1 rounded hover:bg-black/10 transition-colors"
-                            title="Edit assignment"
-                          >
-                            <Settings2 className="h-4 w-4 text-muted-foreground" />
-                          </button>
+                          {isAdmin && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleEditChore(chore);
+                              }}
+                              className="p-1 rounded hover:bg-black/10 transition-colors"
+                              title="Edit assignment"
+                            >
+                              <Settings2 className="h-4 w-4 text-muted-foreground" />
+                            </button>
+                          )}
                         </div>
                       </li>
                     ))}

--- a/nestle-together/src/features/store.ts
+++ b/nestle-together/src/features/store.ts
@@ -300,8 +300,8 @@ export const useAppStore = create<AppState>()(
         activityApi.fetchActivityTimeline(householdId),
 
       fetchTeamOverview: async (householdId) => {
-        const { currentPinCode, isAdmin } = get();
-        if (!isAdmin || !currentPinCode) return [];
+        const { currentPinCode } = get();
+        if (!currentPinCode) return [];
         return activityApi.fetchTeamOverview(householdId, parseInt(currentPinCode, 10));
       },
     }),


### PR DESCRIPTION
## Summary

- **Fixes 403**: The `/team` endpoint only accepted the admin PIN. Now accepts the member PIN too (same logic as `/access`), so members can load team data.
- **Option A — read-only view for non-admins**: Removed the `!isAdmin` early-return in `TeamOverviewAccordion`. All authenticated members now see the Household Overview section with everyone's chore progress.
- **Gear icons remain admin-only**: The reassignment hint and `Settings2` buttons are conditionally rendered only when `isAdmin` is true.

## Test plan

- [ ] Admin logs in → Team tab → sees "Click the gear icon to reassign chores" hint and gear icons on assigned chores
- [ ] Member logs in (member PIN) → Team tab → sees "Household Overview" with chore progress, no hint text, no gear icons
- [ ] New E2E tests in `nestle-together/e2e/team.spec.ts` cover both roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)