### PR TITLE
fix: shared E2E helpers — fix stale form selectors in admin/team specs

### DIFF
--- a/nestle-together/e2e/admin.spec.ts
+++ b/nestle-together/e2e/admin.spec.ts
@@ -1,18 +1,9 @@
 import { test, expect } from '@playwright/test';
-
-const uniqueId = () => Math.random().toString(36).substring(7);
+import { createHousehold, uniqueId } from './helpers';
 
 async function createHouseholdAsAdmin(page: import('@playwright/test').Page) {
   const householdName = `Admin Test ${uniqueId()}`;
-  await page.goto('/');
-  await page.click('text=Create Household');
-  await page.getByLabel(/household name/i).fill(householdName);
-  await page.getByLabel(/your name|nickname/i).first().fill('Admin');
-  await page.getByRole('button', { name: /continue/i }).click();
-  await page.getByLabel(/admin.*pin|pin.*code/i).first().fill('1234');
-  await page.getByRole('button', { name: /create/i }).click();
-  await page.waitForURL(/\/household\//, { timeout: 45000 });
-  await expect(page.locator('h1')).toContainText(householdName, { timeout: 10000 });
+  await createHousehold(page, householdName);
   return page.url();
 }
 

--- a/nestle-together/e2e/helpers.ts
+++ b/nestle-together/e2e/helpers.ts
@@ -1,0 +1,32 @@
+import { expect, type Page } from '@playwright/test';
+
+export const uniqueId = () => Math.random().toString(36).substring(7);
+
+/** Navigate the 2-step CreateHousehold form and wait for the dashboard. */
+export async function createHousehold(page: Page, householdName: string, pin = '1234') {
+  await page.goto('/');
+  await page.click('text=Create Household');
+
+  // Step 1: Household name
+  await page.getByLabel('Household Name').fill(householdName);
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Step 2: Admin PIN — both fields required
+  await page.getByLabel('PIN Code').fill(pin);
+  await page.getByLabel('Confirm Admin PIN').fill(pin);
+  await page.getByRole('button', { name: 'Create Household' }).click();
+
+  await page.waitForURL(/\/household\//, { timeout: 30000 });
+  await expect(page.locator('h1')).toContainText(householdName, { timeout: 15000 });
+
+  return page.url();
+}
+
+/** Fill the PinInput component (4 individual tel inputs, auto-submits on last digit). */
+export async function fillPinInput(page: Page, pin: string) {
+  const inputs = page.locator('input[type="tel"]');
+  await inputs.first().waitFor({ state: 'visible', timeout: 10000 });
+  for (let i = 0; i < pin.length; i++) {
+    await inputs.nth(i).fill(pin[i]);
+  }
+}

--- a/nestle-together/e2e/household.spec.ts
+++ b/nestle-together/e2e/household.spec.ts
@@ -1,35 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
-
-// Generate unique names to avoid conflicts between test runs
-const uniqueId = () => Math.random().toString(36).substring(7);
-
-// Helper: navigate the 2-step CreateHousehold form and wait for the dashboard
-async function createHousehold(page: Page, householdName: string, pin = '1234') {
-  await page.goto('/');
-  await page.click('text=Create Household');
-
-  // Step 1: Household name
-  await page.getByLabel('Household Name').fill(householdName);
-  await page.getByRole('button', { name: 'Continue' }).click();
-
-  // Step 2: Admin PIN (both fields must match)
-  await page.getByLabel('PIN Code').fill(pin);
-  await page.getByLabel('Confirm Admin PIN').fill(pin);
-  await page.getByRole('button', { name: 'Create Household' }).click();
-
-  // Wait for redirect to dashboard
-  await page.waitForURL(/\/household\//, { timeout: 30000 });
-  await expect(page.locator('h1')).toContainText(householdName, { timeout: 15000 });
-}
-
-// Helper: fill the PinInput component (4 individual tel inputs, auto-submits when complete)
-async function fillPinInput(page: Page, pin: string) {
-  const inputs = page.locator('input[type="tel"]');
-  await inputs.first().waitFor({ state: 'visible', timeout: 10000 });
-  for (let i = 0; i < pin.length; i++) {
-    await inputs.nth(i).fill(pin[i]);
-  }
-}
+import { test, expect } from '@playwright/test';
+import { createHousehold, fillPinInput, uniqueId } from './helpers';
 
 test.describe('Household Creation', () => {
   test('can create a new household', async ({ page }) => {

--- a/nestle-together/e2e/team.spec.ts
+++ b/nestle-together/e2e/team.spec.ts
@@ -1,23 +1,8 @@
 import { test, expect } from '@playwright/test';
-
-const uniqueId = () => Math.random().toString(36).substring(7);
+import { createHousehold, fillPinInput, uniqueId } from './helpers';
 
 const ADMIN_PIN = '1234';
 const MEMBER_PIN = '5678';
-
-async function createHousehold(page: import('@playwright/test').Page) {
-  const householdName = `Team Test ${uniqueId()}`;
-  await page.goto('/');
-  await page.click('text=Create Household');
-  await page.getByLabel(/household name/i).fill(householdName);
-  await page.getByLabel(/your name|nickname/i).first().fill('Admin');
-  await page.getByRole('button', { name: /continue/i }).click();
-  await page.getByLabel(/admin.*pin|pin.*code/i).first().fill(ADMIN_PIN);
-  await page.getByRole('button', { name: /create/i }).click();
-  await page.waitForURL(/\/household\//, { timeout: 45000 });
-  await expect(page.locator('h1')).toContainText(householdName, { timeout: 10000 });
-  return page.url();
-}
 
 async function setMemberPin(page: import('@playwright/test').Page) {
   // Navigate to Admin → Settings tab to set member PIN
@@ -37,7 +22,7 @@ async function navigateToTeamTab(page: import('@playwright/test').Page) {
 
 test.describe('Team tab — admin view', () => {
   test('shows Household Overview with reassignment hint', async ({ page }) => {
-    await createHousehold(page);
+    await createHousehold(page, `Team Test ${uniqueId()}`);
     await navigateToTeamTab(page);
 
     await expect(page.locator('text=Household Overview')).toBeVisible();
@@ -45,7 +30,7 @@ test.describe('Team tab — admin view', () => {
   });
 
   test('shows gear icon when chore is assigned', async ({ page }) => {
-    await createHousehold(page);
+    await createHousehold(page, `Team Test ${uniqueId()}`);
 
     // Add a chore via Admin → Chores tab
     await page.getByRole('link', { name: /admin/i }).click();
@@ -69,17 +54,16 @@ test.describe('Team tab — member view', () => {
   let householdAccessUrl: string;
 
   test.beforeEach(async ({ page }) => {
-    const dashboardUrl = await createHousehold(page);
+    const dashboardUrl = await createHousehold(page, `Team Test ${uniqueId()}`, ADMIN_PIN);
     await setMemberPin(page);
 
     // Logout and re-access with member PIN
     householdAccessUrl = dashboardUrl.replace('/household/', '/access/');
-    await page.getByRole('button', { name: /logout|log out/i }).click();
+    await page.getByRole('button', { name: /log out/i }).click();
 
     await page.goto(householdAccessUrl);
-    await page.getByLabel(/pin/i).fill(MEMBER_PIN);
-    await page.getByRole('button', { name: /access|enter|submit/i }).click();
-    await page.waitForURL(/\/household\//, { timeout: 45000 });
+    await fillPinInput(page, MEMBER_PIN);
+    await page.waitForURL(/\/household\//, { timeout: 30000 });
   });
 
   test('shows Household Overview section', async ({ page }) => {


### PR DESCRIPTION
## Summary

- `admin.spec.ts` and `team.spec.ts` both had a stale `createHousehold` helper missing the **Confirm Admin PIN** field and using wrong label selectors — causing every test to time out at `waitForURL(/\/household\//)`
- Extracted `createHousehold` and `fillPinInput` into `e2e/helpers.ts` so all three spec files share one source of truth
- Also fixes member login in `team.spec.ts` to use `fillPinInput` instead of `getByLabel(/pin/i)` (which doesn't match the PinInput component)

## Test plan

- [ ] All admin spec tests pass (no more `waitForURL` timeouts)
- [ ] All team spec tests pass (member login works)
- [ ] household spec tests unaffected (now imports from helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)