### PR TITLE
fix: fill Your Name field in E2E createHousehold helper

### DIFF
--- a/nestle-together/e2e/helpers.ts
+++ b/nestle-together/e2e/helpers.ts
@@ -7,8 +7,9 @@ export async function createHousehold(page: Page, householdName: string, pin = '
   await page.goto('/');
   await page.click('text=Create Household');
 
-  // Step 1: Household name
+  // Step 1: Household name + admin nickname (both required to enable Continue)
   await page.getByLabel('Household Name').fill(householdName);
+  await page.getByLabel('Your Name').fill('Admin');
   await page.getByRole('button', { name: 'Continue' }).click();
 
   // Step 2: Admin PIN — both fields required


### PR DESCRIPTION
## Summary

Step 1 of the household creation form has a required **Your Name** field. Without filling it the Continue button stays disabled, PIN Code never renders, and every E2E test times out.

## Test plan
- [ ] All E2E tests pass (no more `locator.fill: Timeout` on `getByLabel('PIN Code')`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)