### PR TITLE
feat: preview salary slips for the in-progress period

### DIFF
--- a/ChoreMonkey.Core/Feature/Salary/Queries/GetAvailablePeriods/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Salary/Queries/GetAvailablePeriods/Handler.cs
@@ -47,11 +47,35 @@ internal class Handler(IEventStore store)
             .GroupBy(e => (e.PeriodStart.Date, e.PeriodEnd.Date))
             .ToDictionary(g => g.Key, g => g.Last().PeriodId);
 
-        // Generate all completed pay periods from household creation up to today
         var periods = new List<AvailablePeriodDto>();
-        var cursor = GetPaydayOn(today, paydayDay);
 
-        // Walk backwards, generating period boundaries
+        // Prepend the in-progress period — boundaries must match GetCurrentPeriod so the
+        // frontend can recognize it as "current" and offer previews.
+        var paydayThisMonth = new DateTime(today.Year, today.Month, paydayDay, 0, 0, 0, DateTimeKind.Utc);
+        DateTime currentStart, currentEnd;
+        if (today <= paydayThisMonth.Date)
+        {
+            var prevPayday = paydayThisMonth.AddMonths(-1);
+            currentStart = new DateTime(prevPayday.Year, prevPayday.Month, paydayDay, 0, 0, 0, DateTimeKind.Utc).AddDays(1);
+            currentEnd = paydayThisMonth;
+        }
+        else
+        {
+            var nextPayday = paydayThisMonth.AddMonths(1);
+            currentStart = paydayThisMonth.AddDays(1);
+            currentEnd = new DateTime(nextPayday.Year, nextPayday.Month, paydayDay, 0, 0, 0, DateTimeKind.Utc);
+        }
+
+        // Only prepend if the period is still in progress (ends in the future). When
+        // today == payday, the backwards loop below will emit the same period as a
+        // completed-but-unclosed entry — skipping here avoids duplicates.
+        if (currentEnd > today && (!householdCreatedAt.HasValue || currentEnd >= householdCreatedAt.Value))
+        {
+            periods.Add(new AvailablePeriodDto(currentStart, currentEnd, false, null));
+        }
+
+        // Walk backwards generating completed period boundaries
+        var cursor = GetPaydayOn(today, paydayDay);
         for (var i = 0; i < 24; i++) // max 24 months back
         {
             var periodEnd = cursor;
@@ -63,7 +87,6 @@ internal class Handler(IEventStore store)
             if (householdCreatedAt.HasValue && periodEnd < householdCreatedAt.Value)
                 break;
 
-            // Only include completed periods (periodEnd <= today)
             if (periodEnd <= today)
             {
                 var isClosed = closedPeriods.TryGetValue((periodStart.Date, periodEnd.Date), out var periodId);

--- a/nestle-together/src/features/salary/components/SalaryAdmin.tsx
+++ b/nestle-together/src/features/salary/components/SalaryAdmin.tsx
@@ -11,10 +11,43 @@ interface MemberSalaryForm {
   bonusMultiplier: string;
 }
 
-function formatPeriodLabel(period: AvailablePeriod): string {
+function formatPeriodLabel(period: AvailablePeriod, isCurrent: boolean): string {
   const end = new Date(period.periodEnd);
   const label = end.toLocaleDateString('sv-SE', { month: 'long', year: 'numeric' });
-  return period.isClosed ? `${label} ✓` : label;
+  if (period.isClosed) return `${label} ✓`;
+  if (isCurrent) return `${label} (current)`;
+  return label;
+}
+
+function buildPreviewSlip(
+  member: MemberPeriodSummary,
+  periodStart: string,
+  periodEnd: string
+): OfficialSalarySlipResponse {
+  const deductionMult = member.deductionMultiplier || 1;
+  const bonusMult = member.bonusMultiplier || 1;
+  return {
+    periodId: 'preview',
+    periodStart,
+    periodEnd,
+    memberName: member.name,
+    baseSalary: member.baseSalary,
+    deductions: member.missedChores.map((mc) => ({
+      choreName: `${mc.choreName} (${mc.period})`,
+      baseRate: deductionMult !== 0 ? mc.deduction / deductionMult : mc.deduction,
+      multiplier: member.deductionMultiplier,
+      amount: mc.deduction,
+    })),
+    bonuses: member.bonusChores.map((bc) => ({
+      choreName: bc.choreName,
+      baseRate: bonusMult !== 0 ? bc.bonus / bonusMult : bc.bonus,
+      multiplier: member.bonusMultiplier,
+      amount: bc.bonus,
+    })),
+    grossDeductions: member.deductions,
+    grossBonuses: member.bonuses,
+    netPay: member.projected,
+  };
 }
 
 export function SalaryAdmin() {
@@ -32,6 +65,7 @@ export function SalaryAdmin() {
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
   const [history, setHistory] = useState<PeriodPayout[]>([]);
   const [activeSlip, setActiveSlip] = useState<OfficialSalarySlipResponse | null>(null);
+  const [slipIsPreview, setSlipIsPreview] = useState(false);
   const [loadingSlip, setLoadingSlip] = useState<string | null>(null);
 
   // Period selector
@@ -63,8 +97,17 @@ export function SalaryAdmin() {
     const key = `${periodId}-${memberId}`;
     setLoadingSlip(key);
     const slip = await getOfficialSalarySlip(currentHouseholdId, periodId, memberId);
-    if (slip) setActiveSlip(slip);
+    if (slip) {
+      setActiveSlip(slip);
+      setSlipIsPreview(false);
+    }
     setLoadingSlip(null);
+  }
+
+  function previewSlip(member: MemberPeriodSummary) {
+    if (!periodData) return;
+    setActiveSlip(buildPreviewSlip(member, periodData.periodStart, periodData.periodEnd));
+    setSlipIsPreview(true);
   }
 
   function startEditing(member: MemberPeriodSummary) {
@@ -96,6 +139,13 @@ export function SalaryAdmin() {
 
   const selectedPeriod = availablePeriods[selectedPeriodIdx] ?? null;
   const periodEnded = selectedPeriod ? new Date() > new Date(selectedPeriod.periodEnd) : false;
+  const isCurrentPeriod = !!(
+    selectedPeriod &&
+    !selectedPeriod.isClosed &&
+    periodData &&
+    selectedPeriod.periodStart === periodData.periodStart &&
+    selectedPeriod.periodEnd === periodData.periodEnd
+  );
 
   async function handleClosePeriod() {
     if (!currentHouseholdId || !selectedPeriod || selectedPeriod.isClosed) return;
@@ -266,13 +316,43 @@ export function SalaryAdmin() {
                 onChange={(e) => setSelectedPeriodIdx(Number(e.target.value))}
                 className="period-select"
               >
-                {availablePeriods.map((p, i) => (
-                  <option key={i} value={i}>
-                    {formatPeriodLabel(p)}
-                  </option>
-                ))}
+                {availablePeriods.map((p, i) => {
+                  const isCur =
+                    !p.isClosed &&
+                    !!periodData &&
+                    p.periodStart === periodData.periodStart &&
+                    p.periodEnd === periodData.periodEnd;
+                  return (
+                    <option key={i} value={i}>
+                      {formatPeriodLabel(p, isCur)}
+                    </option>
+                  );
+                })}
               </select>
             </div>
+
+            {isCurrentPeriod && periodData && (
+              <div className="history-section" style={{ marginTop: '1rem' }}>
+                <p className="text-xs text-muted-foreground mb-3">
+                  Projected payouts so far — final amounts will be set when the period closes.
+                </p>
+                <div className="history-payouts">
+                  {periodData.members.map((m) => (
+                    <div key={m.memberId} className="history-payout-row">
+                      <span className="payout-name">{m.name}</span>
+                      <span className="payout-amount">{m.projected.toFixed(0)} kr</span>
+                      <button
+                        className="view-slip-btn"
+                        onClick={() => previewSlip(m)}
+                        disabled={m.baseSalary === 0}
+                      >
+                        Preview Slip
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {selectedPeriod && !selectedPeriod.isClosed && (
               <div className="period-actions">
@@ -319,7 +399,16 @@ export function SalaryAdmin() {
       </div>
 
       {/* Salary Slip Modal */}
-      {activeSlip && <SalarySlip slip={activeSlip} onClose={() => setActiveSlip(null)} />}
+      {activeSlip && (
+        <SalarySlip
+          slip={activeSlip}
+          isPreview={slipIsPreview}
+          onClose={() => {
+            setActiveSlip(null);
+            setSlipIsPreview(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/nestle-together/src/features/salary/components/SalarySlip.css
+++ b/nestle-together/src/features/salary/components/SalarySlip.css
@@ -23,6 +23,18 @@
   padding: 2rem;
 }
 
+/* Preview banner */
+.slip-preview-banner {
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  color: #795548;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
 /* Header */
 .slip-header {
   text-align: center;

--- a/nestle-together/src/features/salary/components/SalarySlip.tsx
+++ b/nestle-together/src/features/salary/components/SalarySlip.tsx
@@ -4,9 +4,10 @@ import './SalarySlip.css';
 interface SalarySlipProps {
   slip: OfficialSalarySlipResponse;
   onClose: () => void;
+  isPreview?: boolean;
 }
 
-export function SalarySlip({ slip, onClose }: SalarySlipProps) {
+export function SalarySlip({ slip, onClose, isPreview = false }: SalarySlipProps) {
   const formatDate = (dateStr: string) =>
     new Date(dateStr).toLocaleDateString('sv-SE', {
       year: 'numeric',
@@ -20,8 +21,13 @@ export function SalarySlip({ slip, onClose }: SalarySlipProps) {
     <div className="salary-slip-overlay" onClick={onClose}>
       <div className="salary-slip" onClick={(e) => e.stopPropagation()}>
         <div className="slip-content">
+          {isPreview && (
+            <div className="slip-preview-banner">
+              ⚠️ Preview — period not closed. Final amounts may change.
+            </div>
+          )}
           <header className="slip-header">
-            <h2>Salary Slip</h2>
+            <h2>{isPreview ? 'Salary Slip (Preview)' : 'Salary Slip'}</h2>
             <div className="slip-period">
               {formatDate(slip.periodStart)} &mdash; {formatDate(slip.periodEnd)}
             </div>


### PR DESCRIPTION
## Summary
- Admins can preview a projected salary slip for the current (un-closed) period from the Salary admin panel. No events are appended — the slip is rendered from the existing `GetCurrentPeriod` projection, and the modal is clearly marked as a preview (banner + "(Preview)" title suffix).
- Aligns `GetAvailablePeriods` with `GetCurrentPeriod` so the in-progress period is always present in the period dropdown, even on days after the configured payday. Previously the dropdown only included the in-progress period when `today < paydayThisMonth`, so between payday and end-of-month the frontend's `isCurrentPeriod` check failed and no preview could be shown.

## Test plan
- [ ] CI green (dotnet + vitest + playwright)
- [ ] On a day before payday, open Salary admin → in-progress period is the default selected → "Preview Slip" buttons render → clicking one opens the slip modal with the preview banner.
- [ ] On a day after payday (e.g. payday = 25, today = 26), in-progress period `(26th → next 25th)` shows up in the dropdown as "(current)" and preview still works.
- [ ] Closed periods still show "View Slip" (official) with no banner.
- [ ] Setting a member's base salary to 0 disables the "Preview Slip" button for that member.