### PR TITLE
fix: show full missed-chore dates on salary slip (stop cropping)

### DIFF
--- a/nestle-together/src/features/salary/components/SalarySlip.css
+++ b/nestle-together/src/features/salary/components/SalarySlip.css
@@ -98,12 +98,16 @@
 .slip-table td {
   padding: 0.35rem 0.5rem;
   border-bottom: 1px solid #f0f0f0;
+  vertical-align: top;
 }
 
 .slip-table .chore-name {
-  max-width: 160px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.slip-table th:not(:first-child),
+.slip-table td:not(.chore-name) {
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #40. The salary slip preview packs the missed-instance date into \`choreName\` (\"Dishes (2026-04-15)\"), but \`.chore-name\` was clipped with \`max-width: 160px\` + \`text-overflow: ellipsis\` + \`white-space: nowrap\`, hiding exactly the trailing date.
- Let the chore column wrap (\`word-break: break-word\`) and keep the Rate/Mult/Amount columns single-line so the grid stays readable.
- Add \`vertical-align: top\` so wrapped rows line up with the numeric columns cleanly.

## Test plan
- [ ] CI green
- [ ] Open a preview slip for a member with multiple missed instances → dates are fully visible, no ellipsis.
- [ ] Open an official (closed-period) slip with a long chore name → name wraps, other columns still on one line.
- [ ] Print view (\`window.print()\`) still legible.