### PR TITLE
fix(ci): wait for /health before running e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,13 +105,33 @@ jobs:
         working-directory: nestle-together
         run: npx playwright install --with-deps chromium
 
-      # Start API in background
-      - name: Start API
+      # Start API in background, capture logs, and wait for /health to actually respond.
+      # Replaces a fixed `sleep 10` that was racing with API startup on slower runners
+      # and silently masking failures (`curl ... || echo skipped`).
+      - name: Start API and wait for /health
         run: |
-          dotnet run --project ChoreMonkey.ApiService --configuration Release --no-build &
-          echo "Waiting for API to start..."
-          sleep 10
-          curl -s http://localhost:5536/health || echo "Health check skipped"
+          mkdir -p api-logs
+          dotnet run --project ChoreMonkey.ApiService --configuration Release --no-build \
+            > api-logs/api.log 2>&1 &
+          echo $! > api-logs/api.pid
+
+          echo "Waiting for API on http://localhost:5536/health (up to 60s)..."
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:5536/health > /dev/null 2>&1; then
+              echo "API ready after ${i}s"
+              exit 0
+            fi
+            if ! kill -0 "$(cat api-logs/api.pid)" 2>/dev/null; then
+              echo "::error::API process exited before becoming healthy"
+              tail -n 200 api-logs/api.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "::error::API did not become healthy within 60s"
+          tail -n 200 api-logs/api.log
+          exit 1
         env:
           ASPNETCORE_URLS: http://localhost:5536
           ASPNETCORE_ENVIRONMENT: Development
@@ -128,4 +148,12 @@ jobs:
         with:
           name: playwright-report
           path: nestle-together/playwright-report/
+          retention-days: 7
+
+      - name: Upload API logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: api-logs
+          path: api-logs/
           retention-days: 7


### PR DESCRIPTION
## Summary
Every recent feature-branch CI run has failed \`e2e-tests\` while the same commit passed once merged to main. Root cause is a race between API startup and Playwright's first navigation:

- The previous step started the API with \`&\` and \`sleep 10\`, then ran \`curl -s ... || echo \"Health check skipped\"\` — which silently masks any failure. On slower runners 10s wasn't enough, so the first test click hit an unready API and timed out (\`actionTimeout: 5000ms\`).
- Symptoms: timeouts on \`getByRole('tab', { name: /settings/i })\`, \`add chore\` etc — i.e. everything that depends on a backend response.

This replaces the fixed sleep with a 60s polling loop on \`/health\` that:
- Exits 0 immediately when the API responds.
- Exits 1 if the API process dies before becoming healthy (so we don't silently run e2e against nothing).
- Exits 1 if the timeout elapses, dumping the last 200 log lines.
- Captures \`api-logs/api.log\` and uploads it as a CI artifact on failure for diagnosis.

## Test plan
- [ ] CI green on this PR (this PR's own e2e run is the test).
- [ ] Future PRs that don't touch e2e tests should also be green.