### PR TITLE
fix(e2e): query admin sub-tabs by button role, not tab role

### DIFF
--- a/nestle-together/e2e/admin.spec.ts
+++ b/nestle-together/e2e/admin.spec.ts
@@ -80,8 +80,9 @@ test.describe('Salary admin', () => {
     await page.getByRole('link', { name: /admin/i }).click();
     await page.waitForURL(/\/admin/, { timeout: 10000 });
 
-    // Salary tab should be accessible
-    await page.getByRole('tab', { name: /salary/i }).click();
+    // Salary tab should be accessible. Admin sub-tabs are rendered as plain
+    // <button>s in AdminDashboard.tsx (no role="tab"), so query by button role.
+    await page.getByRole('button', { name: /salaries/i }).click();
     await expect(page.locator('text=/salary management/i')).toBeVisible({ timeout: 5000 });
   });
 
@@ -90,7 +91,7 @@ test.describe('Salary admin', () => {
     await page.getByRole('link', { name: /admin/i }).click();
     await page.waitForURL(/\/admin/, { timeout: 10000 });
 
-    await page.getByRole('tab', { name: /salary/i }).click();
+    await page.getByRole('button', { name: /salaries/i }).click();
 
     // The close period button should be disabled — period hasn't ended yet
     const closeBtn = page.locator('button.close-period-btn');

--- a/nestle-together/e2e/team.spec.ts
+++ b/nestle-together/e2e/team.spec.ts
@@ -5,10 +5,11 @@ const ADMIN_PIN = '1234';
 const MEMBER_PIN = '5678';
 
 async function setMemberPin(page: import('@playwright/test').Page) {
-  // Navigate to Admin → Settings tab to set member PIN
+  // Navigate to Admin → Settings tab to set member PIN. Admin sub-tabs are
+  // plain <button>s in AdminDashboard.tsx (no role="tab"), so query by button role.
   await page.getByRole('link', { name: /admin/i }).click();
   await page.waitForURL(/\/admin/, { timeout: 10000 });
-  await page.getByRole('tab', { name: /settings/i }).click();
+  await page.getByRole('button', { name: /settings/i }).click();
 
   await page.locator('#newMemberPin').fill(MEMBER_PIN);
   await page.getByRole('button', { name: /set member pin/i }).click();


### PR DESCRIPTION
## Summary
Three e2e specs were querying admin sub-tabs as \`getByRole('tab', ...)\`, but \`AdminDashboard.tsx:90-101\` renders them as plain \`<button>\` elements with no \`role=\"tab\"\` attribute. The locator never matched → 5s timeout. Switching to \`getByRole('button', { name: /salaries|settings/i })\` matches the actual markup.

This is a pre-existing bug — \`e2e-tests\` only runs on PRs and isn't a required check, so failures piled up unnoticed. Should turn **6 of the 9** currently-failing e2e tests green:
- \`admin.spec.ts:78\` — Salary admin renders
- \`admin.spec.ts:88\` — Close period button disabled
- All four \`team.spec.ts\` tests (they all hit the broken \`tab\` selector via \`setMemberPin\` in \`beforeEach\`)

## Out of scope (separate follow-ups)
- \`household.spec.ts:132,142\` — Edit Profile dialog never opens; needs UX investigation.
- \`household.spec.ts:167\` — \`/invite/i\` button not on the page; likely renamed.

## Test plan
- [ ] CI green on the 6 fixed tests
- [ ] The 3 unrelated household.spec.ts failures remain (and aren't masked by this change)