### PR TITLE
fix(e2e): query admin sub-tabs by button role, not tab role

### DIFF
--- a/nestle-together/e2e/admin.spec.ts
+++ b/nestle-together/e2e/admin.spec.ts
@@ -80,8 +80,9 @@ test.describe('Salary admin', () => {
     await page.getByRole('link', { name: /admin/i }).click();
     await page.waitForURL(/\/admin/, { timeout: 10000 });
 
-    // Salary tab should be accessible
-    await page.getByRole('tab', { name: /salary/i }).click();
+    // Salary tab should be accessible. Admin sub-tabs are rendered as plain
+    // <button>s in AdminDashboard.tsx (no role="tab"), so query by button role.
+    await page.getByRole('button', { name: /salaries/i }).click();
     await expect(page.locator('text=/salary management/i')).toBeVisible({ timeout: 5000 });
   });
 
@@ -90,7 +91,7 @@ test.describe('Salary admin', () => {
     await page.getByRole('link', { name: /admin/i }).click();
     await page.waitForURL(/\/admin/, { timeout: 10000 });
 
-    await page.getByRole('tab', { name: /salary/i }).click();
+    await page.getByRole('button', { name: /salaries/i }).click();
 
     // The close period button should be disabled — period hasn't ended yet
     const closeBtn = page.locator('button.close-period-btn');

--- a/nestle-together/e2e/team.spec.ts
+++ b/nestle-together/e2e/team.spec.ts
@@ -5,10 +5,11 @@ const ADMIN_PIN = '1234';
 const MEMBER_PIN = '5678';
 
 async function setMemberPin(page: import('@playwright/test').Page) {
-  // Navigate to Admin → Settings tab to set member PIN
+  // Navigate to Admin → Settings tab to set member PIN. Admin sub-tabs are
+  // plain <button>s in AdminDashboard.tsx (no role="tab"), so query by button role.
   await page.getByRole('link', { name: /admin/i }).click();
   await page.waitForURL(/\/admin/, { timeout: 10000 });
-  await page.getByRole('tab', { name: /settings/i }).click();
+  await page.getByRole('button', { name: /settings/i }).click();
 
   await page.locator('#newMemberPin').fill(MEMBER_PIN);
   await page.getByRole('button', { name: /set member pin/i }).click();


### PR DESCRIPTION
## Summary
- Admin sub-tabs render as `<button>` elements, not ARIA `tab`s. Update Playwright selectors in `admin.spec.ts` and `team.spec.ts` to match.

## Test plan
- [ ] `npm run test:e2e` passes locally
- [ ] CI e2e job is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)