### PR TITLE
fix(pwa): redirect HTTP to HTTPS so install prompt fires

### DIFF
--- a/nestle-together/public/web.config
+++ b/nestle-together/public/web.config
@@ -7,6 +7,13 @@
     </staticContent>
     <rewrite>
       <rules>
+        <rule name="HTTPS Redirect" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{HTTPS}" pattern="off" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:0}" redirectType="Permanent" />
+        </rule>
         <rule name="SPA Routes" stopProcessing="true">
           <match url=".*" />
           <conditions logicalGrouping="MatchAll">


### PR DESCRIPTION
## Summary
PWAs need a secure context. The IIS host serves both http:// and https://; landing on http:// silently breaks SW registration and the install prompt. Add a 301 rewrite to force HTTPS.

## Test plan
- [ ] After deploy: `curl -I http://choremonkey.itsybit.se/` returns 301 to https://
- [ ] Chrome devtools → Application → Manifest shows "Installable"
- [ ] Install icon appears in the address bar after engagement

🤖 Generated with [Claude Code](https://claude.com/claude-code)