### PR TITLE
fix(e2e): align failing specs with current dashboard UI

### DIFF
--- a/nestle-together/e2e/helpers.ts
+++ b/nestle-together/e2e/helpers.ts
@@ -31,3 +31,30 @@ export async function fillPinInput(page: Page, pin: string) {
     await inputs.nth(i).fill(pin[i]);
   }
 }
+
+type DashboardTab = 'chores' | 'team' | 'activity' | 'admin';
+
+/**
+ * Navigate to a dashboard tab. Chores/Team/Activity render as <button>s in
+ * HouseholdDashboard's bottom nav; Admin is a <Link>. If we're on /admin (or
+ * any sub-route), we go back to the dashboard root first since those tabs
+ * only exist there.
+ */
+export async function navigateToTab(page: Page, tab: DashboardTab) {
+  const match = page.url().match(/\/household\/([^/?#]+)/);
+  if (!match) throw new Error('navigateToTab: not on a household page');
+  const householdId = match[1];
+
+  if (!new RegExp(`/household/${householdId}/?$`).test(page.url())) {
+    await page.goto(`/household/${householdId}`);
+    await expect(page.locator('h1')).toBeVisible({ timeout: 15000 });
+  }
+
+  if (tab === 'admin') {
+    await page.getByRole('link', { name: /admin/i }).click();
+    await page.waitForURL(/\/admin/, { timeout: 10000 });
+    return;
+  }
+
+  await page.getByRole('button', { name: new RegExp(`^${tab}$`, 'i') }).click();
+}

--- a/nestle-together/e2e/household.spec.ts
+++ b/nestle-together/e2e/household.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { createHousehold, fillPinInput, uniqueId } from './helpers';
+import { createHousehold, fillPinInput, navigateToTab, uniqueId } from './helpers';
 
 test.describe('Household Creation', () => {
   test('can create a new household', async ({ page }) => {
@@ -136,7 +136,11 @@ test.describe('Profile', () => {
     await page.getByLabel(/nickname/i).fill('NewName');
     await page.getByRole('button', { name: /save/i }).click();
 
-    await expect(page.getByText('NewName', { exact: true })).toBeVisible({ timeout: 10000 });
+    // The dashboard avatar shows initials only — to verify the nickname
+    // change persisted, switch to the Team tab where members are listed by
+    // nickname.
+    await navigateToTab(page, 'team');
+    await expect(page.getByText('NewName', { exact: true }).first()).toBeVisible({ timeout: 10000 });
   });
 
   test('can set and clear status', async ({ page }) => {
@@ -146,20 +150,23 @@ test.describe('Profile', () => {
     await page.getByLabel(/status/i).fill('Busy testing!');
     await page.getByRole('button', { name: /save/i }).click();
 
-    await page.waitForTimeout(1500);
+    // The status pulse ring only renders on member avatars in the Team tab.
+    // Use the combo selector .animate-pulse.absolute to skip unrelated pulses
+    // (skeleton loaders, ConnectionStatus reconnection dot).
+    await navigateToTab(page, 'team');
+    const statusPulse = page.locator('.animate-pulse.absolute');
+    await expect(statusPulse.first()).toBeVisible({ timeout: 5000 });
 
-    // Avatar should have status ring (pulsing)
-    await expect(page.locator('.animate-pulse')).toBeVisible({ timeout: 5000 });
-
-    // Reopen and clear
+    // Reopen and clear (Edit Profile lives in the dashboard header, available
+    // from any tab).
     await page.getByRole('button', { name: /edit profile/i }).click();
     await page.getByLabel(/status/i).waitFor({ state: 'visible', timeout: 5000 });
     await page.getByRole('button', { name: /clear/i }).click();
     await page.getByRole('button', { name: /save/i }).click();
 
-    await page.waitForTimeout(1500);
-
-    await expect(page.locator('.animate-pulse')).not.toBeVisible({ timeout: 5000 });
+    // Wait for the dialog to auto-close, then verify the status pulse is gone.
+    await expect(page.getByRole('dialog')).toHaveCount(0, { timeout: 5000 });
+    await expect(statusPulse).toHaveCount(0, { timeout: 5000 });
   });
 });
 
@@ -168,7 +175,9 @@ test.describe('Invites', () => {
     const householdName = `Invite Test ${uniqueId()}`;
     await createHousehold(page, householdName);
 
-    await page.getByRole('button', { name: /invite/i }).click();
+    // The Invite button lives inside the Team tab (TeamTab.tsx).
+    await navigateToTab(page, 'team');
+    await page.getByRole('button', { name: /^invite$/i }).click();
 
     // Dialog opens - should show "Invite Family Member" title
     await expect(page.getByRole('heading', { name: /invite family member/i })).toBeVisible({ timeout: 5000 });

--- a/nestle-together/e2e/team.spec.ts
+++ b/nestle-together/e2e/team.spec.ts
@@ -1,14 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { createHousehold, fillPinInput, uniqueId } from './helpers';
+import { createHousehold, fillPinInput, navigateToTab, uniqueId } from './helpers';
 
 const ADMIN_PIN = '1234';
 const MEMBER_PIN = '5678';
 
 async function setMemberPin(page: import('@playwright/test').Page) {
-  // Navigate to Admin → Settings tab to set member PIN. Admin sub-tabs are
-  // plain <button>s in AdminDashboard.tsx (no role="tab"), so query by button role.
-  await page.getByRole('link', { name: /admin/i }).click();
-  await page.waitForURL(/\/admin/, { timeout: 10000 });
+  await navigateToTab(page, 'admin');
   await page.getByRole('button', { name: /settings/i }).click();
 
   await page.locator('#newMemberPin').fill(MEMBER_PIN);
@@ -16,15 +13,15 @@ async function setMemberPin(page: import('@playwright/test').Page) {
   await expect(page.locator('text=/member pin updated/i')).toBeVisible({ timeout: 5000 });
 }
 
-async function navigateToTeamTab(page: import('@playwright/test').Page) {
-  await page.getByRole('link', { name: /team/i }).click();
+async function goToTeamTab(page: import('@playwright/test').Page) {
+  await navigateToTab(page, 'team');
   await expect(page.locator('text=Household Overview')).toBeVisible({ timeout: 10000 });
 }
 
 test.describe('Team tab — admin view', () => {
   test('shows Household Overview with reassignment hint', async ({ page }) => {
     await createHousehold(page, `Team Test ${uniqueId()}`);
-    await navigateToTeamTab(page);
+    await goToTeamTab(page);
 
     await expect(page.locator('text=Household Overview')).toBeVisible();
     await expect(page.locator('text=/click the gear icon to reassign/i')).toBeVisible();
@@ -33,21 +30,33 @@ test.describe('Team tab — admin view', () => {
   test('shows gear icon when chore is assigned', async ({ page }) => {
     await createHousehold(page, `Team Test ${uniqueId()}`);
 
-    // Add a chore via Admin → Chores tab
-    await page.getByRole('link', { name: /admin/i }).click();
-    await page.waitForURL(/\/admin/, { timeout: 10000 });
+    // Chores are added from the main Chores tab, not /admin.
+    await navigateToTab(page, 'chores');
     await page.getByRole('button', { name: /add chore/i }).click();
-    await page.getByLabel(/name|title/i).fill('Dishes');
-    await page.getByRole('button', { name: /add|create|save/i }).last().click();
+    await page.getByLabel(/chore name/i).waitFor({ state: 'visible' });
+    await page.getByLabel(/chore name/i).fill('Dishes');
+    const submit = page.getByRole('button', { name: /add chore/i }).last();
+    await submit.scrollIntoViewIfNeeded();
+    await submit.click();
     await expect(page.locator('text=Dishes')).toBeVisible({ timeout: 5000 });
 
-    await navigateToTeamTab(page);
+    // Assign it to everyone via the admin Chores tab so it appears under a
+    // member's accordion in the Team overview (the gear only renders for
+    // assigned chores).
+    await navigateToTab(page, 'admin');
+    await page.getByRole('button', { name: /^chores$/i }).click();
+    await page.getByTitle('Assign').first().click();
+    await page.getByRole('checkbox', { name: /assign to everyone/i }).check();
+    await page.getByRole('button', { name: /save/i }).click();
+    await expect(page.locator('text=Everyone').first()).toBeVisible({ timeout: 5000 });
+
+    await goToTeamTab(page);
 
     // Expand admin's accordion entry
     await page.locator('[data-radix-collection-item]').first().click();
 
     // Gear icon should be present for assigned chores
-    await expect(page.locator('[title="Edit assignment"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[title="Edit assignment"]').first()).toBeVisible({ timeout: 5000 });
   });
 });
 
@@ -68,12 +77,12 @@ test.describe('Team tab — member view', () => {
   });
 
   test('shows Household Overview section', async ({ page }) => {
-    await navigateToTeamTab(page);
+    await goToTeamTab(page);
     await expect(page.locator('text=Household Overview')).toBeVisible();
   });
 
   test('does not show reassignment hint or gear icons', async ({ page }) => {
-    await navigateToTeamTab(page);
+    await goToTeamTab(page);
 
     await expect(page.locator('text=/click the gear icon to reassign/i')).not.toBeVisible();
     await expect(page.locator('[title="Edit assignment"]')).not.toBeVisible();

--- a/nestle-together/e2e/team.spec.ts
+++ b/nestle-together/e2e/team.spec.ts
@@ -67,11 +67,14 @@ test.describe('Team tab — member view', () => {
     const dashboardUrl = await createHousehold(page, `Team Test ${uniqueId()}`, ADMIN_PIN);
     await setMemberPin(page);
 
-    // Logout and re-access with member PIN
+    // setMemberPin leaves us on /admin, where there's no Log out button —
+    // it lives in the HouseholdDashboard header. Navigate back first.
+    await navigateToTab(page, 'chores');
+
     householdAccessUrl = dashboardUrl.replace('/household/', '/access/');
     await page.getByRole('button', { name: /log out/i }).click();
 
-    await page.goto(householdAccessUrl);
+    await page.waitForURL(/\/access\//, { timeout: 10000 });
     await fillPinInput(page, MEMBER_PIN);
     await page.waitForURL(/\/household\//, { timeout: 30000 });
   });


### PR DESCRIPTION
## Summary

Six e2e tests have been failing on every PR (same set of 21 failing attachments since at least PR #44). The selectors had drifted from the current dashboard layout — they queried the wrong ARIA role or expected elements that only mount on a different tab.

### Root causes

| failing test | root cause |
| --- | --- |
| `Profile › can change nickname` | dashboard avatar shows initials only — the literal "NewName" text never appears on `/household/:id` |
| `Profile › can set and clear status` | `.animate-pulse` status ring is in `TeamTab.tsx`, not the header |
| `Invites › can generate invite link` | the Invite button is rendered inside `TeamTab`, not on the Chores tab |
| `Team tab — admin/member: …` (4 tests) | `getByRole('link', { name: /team/i })` — but the Team tab is a `<button>` in the bottom nav |
| `Team tab — admin: shows gear icon when chore is assigned` | tried to add a chore from `/admin` (no Add Chore button there) and never assigned it (gear only renders for assigned chores) |

### What changed

- `helpers.ts`: new `navigateToTab(page, tab)` that picks the right role per tab and routes back to `/household/:id` first when called from `/admin`.
- `household.spec.ts`: switch to Team tab before asserting nickname / status pulse / invite button.
- `team.spec.ts`: use the new helper; rewrite the gear-icon test so the chore is added on the main tab and assigned-to-everyone via Admin → Chores before checking the Team accordion.

## Test plan

- [ ] CI `e2e-tests` job goes green
- [ ] No new flakes in the previously-passing tests (`Household Creation`, `Chores`, `Admin tab`, `Settings: household slug`, `Salary admin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)