### PR TITLE
feat(changelog): dedicated /changelog page

### DIFF
--- a/nestle-together/src/App.tsx
+++ b/nestle-together/src/App.tsx
@@ -10,6 +10,7 @@ import AccessHousehold from "./pages/AccessHousehold";
 import HouseholdDashboard from "./pages/HouseholdDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import SlugResolver from "./pages/SlugResolver";
+import Changelog from "./pages/Changelog";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -29,6 +30,7 @@ const App = () => (
           <Route path="/household/:id" element={<HouseholdDashboard />} />
           <Route path="/household/:id/admin" element={<AdminDashboard />} />
           <Route path="/h/:slug" element={<SlugResolver />} />
+          <Route path="/changelog" element={<Changelog />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/nestle-together/src/components/ChangelogList.tsx
+++ b/nestle-together/src/components/ChangelogList.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { Sparkles, Bug, Wrench, Zap } from 'lucide-react';
+
+export interface ChangelogEntry {
+  hash: string;
+  shortHash: string;
+  message: string;
+  date: string;
+  author: string;
+  type: 'feature' | 'fix' | 'refactor' | 'update';
+  displayMessage: string;
+}
+
+export interface Changelog {
+  generated: string;
+  commits: ChangelogEntry[];
+}
+
+const typeConfig = {
+  feature: { icon: Sparkles, color: 'text-green-500', bg: 'bg-green-100', label: 'New' },
+  fix: { icon: Bug, color: 'text-amber-500', bg: 'bg-amber-100', label: 'Fix' },
+  refactor: { icon: Wrench, color: 'text-blue-500', bg: 'bg-blue-100', label: 'Improved' },
+  update: { icon: Zap, color: 'text-purple-500', bg: 'bg-purple-100', label: 'Update' },
+};
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+interface ChangelogListProps {
+  /** When true, the component fetches /changelog.json itself. */
+  autoLoad?: boolean;
+  /** Inject pre-loaded changelog data. Wins over autoLoad. */
+  changelog?: Changelog | null;
+}
+
+/**
+ * Renders the changelog as a date-grouped list. Used inside WhatsNewDialog
+ * (modal) and on the /changelog page.
+ */
+export function ChangelogList({ autoLoad = true, changelog: injected }: ChangelogListProps) {
+  const [fetched, setFetched] = useState<Changelog | null>(null);
+
+  useEffect(() => {
+    if (!autoLoad || injected) return;
+    fetch('/changelog.json')
+      .then((res) => res.json())
+      .then((data: Changelog) => setFetched(data))
+      .catch((err) => console.error('Failed to load changelog', err));
+  }, [autoLoad, injected]);
+
+  const data = injected ?? fetched;
+
+  if (!data) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">Loading...</p>
+    );
+  }
+
+  const groupedByDate = data.commits.reduce((acc, commit) => {
+    const date = commit.date;
+    if (!acc[date]) acc[date] = [];
+    acc[date].push(commit);
+    return acc;
+  }, {} as Record<string, ChangelogEntry[]>);
+
+  return (
+    <div className="space-y-6">
+      {Object.entries(groupedByDate).map(([date, commits]) => (
+        <div key={date}>
+          <h3 className="text-xs font-semibold text-muted-foreground mb-2 sticky top-0 bg-background py-1">
+            {formatDate(date)}
+          </h3>
+          <div className="space-y-2">
+            {commits.map((commit) => {
+              const config = typeConfig[commit.type];
+              const Icon = config.icon;
+              return (
+                <div
+                  key={commit.hash}
+                  className="flex items-start gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors"
+                >
+                  <div className={`p-1.5 rounded-md ${config.bg}`}>
+                    <Icon className={`w-3.5 h-3.5 ${config.color}`} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm leading-snug">{commit.displayMessage}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/nestle-together/src/components/WhatsNewDialog.tsx
+++ b/nestle-together/src/components/WhatsNewDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Sparkles, Bug, Wrench, Zap, Server, Monitor } from 'lucide-react';
+import { Sparkles, Server, Monitor } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -9,33 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-
-interface ChangelogEntry {
-  hash: string;
-  shortHash: string;
-  message: string;
-  date: string;
-  author: string;
-  type: 'feature' | 'fix' | 'refactor' | 'update';
-  displayMessage: string;
-}
-
-interface Changelog {
-  generated: string;
-  commits: ChangelogEntry[];
-}
-
-const typeConfig = {
-  feature: { icon: Sparkles, color: 'text-green-500', bg: 'bg-green-100', label: 'New' },
-  fix: { icon: Bug, color: 'text-amber-500', bg: 'bg-amber-100', label: 'Fix' },
-  refactor: { icon: Wrench, color: 'text-blue-500', bg: 'bg-blue-100', label: 'Improved' },
-  update: { icon: Zap, color: 'text-purple-500', bg: 'bg-purple-100', label: 'Update' },
-};
-
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
+import { ChangelogList, type Changelog } from '@/components/ChangelogList';
 
 interface WhatsNewDialogProps {
   variant?: 'icon' | 'button' | 'controlled';
@@ -55,7 +29,7 @@ export function WhatsNewDialog({ variant = 'icon', open: controlledOpen, onOpenC
   const [changelog, setChangelog] = useState<Changelog | null>(null);
   const [apiVersion, setApiVersion] = useState<ApiVersion | null>(null);
   const [internalOpen, setInternalOpen] = useState(false);
-  
+
   const isControlled = variant === 'controlled';
   const open = isControlled ? controlledOpen ?? false : internalOpen;
   const setOpen = isControlled ? (onOpenChange ?? (() => {})) : setInternalOpen;
@@ -71,24 +45,16 @@ export function WhatsNewDialog({ variant = 'icon', open: controlledOpen, onOpenC
     if (open && !changelog) {
       fetch('/changelog.json')
         .then(res => res.json())
-        .then(data => setChangelog(data))
+        .then((data: Changelog) => setChangelog(data))
         .catch(err => console.error('Failed to load changelog', err));
     }
     if (open && !apiVersion) {
       fetch(`${API_BASE_URL}/api/version`)
         .then(res => res.json())
-        .then(data => setApiVersion(data))
+        .then((data: ApiVersion) => setApiVersion(data))
         .catch(err => console.error('Failed to load API version', err));
     }
   }, [open, changelog, apiVersion]);
-
-  // Group commits by date
-  const groupedByDate = changelog?.commits.reduce((acc, commit) => {
-    const date = commit.date;
-    if (!acc[date]) acc[date] = [];
-    acc[date].push(commit);
-    return acc;
-  }, {} as Record<string, ChangelogEntry[]>) ?? {};
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -131,42 +97,7 @@ export function WhatsNewDialog({ variant = 'icon', open: controlledOpen, onOpenC
           </div>
         </DialogHeader>
         <ScrollArea className="h-[60vh] pr-4">
-          {!changelog ? (
-            <p className="text-sm text-muted-foreground text-center py-8">
-              Loading...
-            </p>
-          ) : (
-            <div className="space-y-6">
-              {Object.entries(groupedByDate).map(([date, commits]) => (
-                <div key={date}>
-                  <h3 className="text-xs font-semibold text-muted-foreground mb-2 sticky top-0 bg-background py-1">
-                    {formatDate(date)}
-                  </h3>
-                  <div className="space-y-2">
-                    {commits.map((commit) => {
-                      const config = typeConfig[commit.type];
-                      const Icon = config.icon;
-                      return (
-                        <div
-                          key={commit.hash}
-                          className="flex items-start gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors"
-                        >
-                          <div className={`p-1.5 rounded-md ${config.bg}`}>
-                            <Icon className={`w-3.5 h-3.5 ${config.color}`} />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm leading-snug">
-                              {commit.displayMessage}
-                            </p>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+          <ChangelogList autoLoad={false} changelog={changelog} />
         </ScrollArea>
       </DialogContent>
     </Dialog>

--- a/nestle-together/src/pages/Changelog.tsx
+++ b/nestle-together/src/pages/Changelog.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, Sparkles, Server, Monitor } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ChangelogList, type Changelog as ChangelogData } from '@/components/ChangelogList';
+
+interface ApiVersion {
+  version: string;
+  buildTime: string;
+  gitSha: string;
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://localhost:7422';
+
+export default function Changelog() {
+  const [changelog, setChangelog] = useState<ChangelogData | null>(null);
+  const [apiVersion, setApiVersion] = useState<ApiVersion | null>(null);
+
+  const frontendVersion = {
+    version: typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev',
+    gitSha: typeof __GIT_SHA__ !== 'undefined' ? __GIT_SHA__ : 'local',
+    buildTime: typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : 'unknown',
+  };
+
+  useEffect(() => {
+    fetch('/changelog.json')
+      .then((res) => res.json())
+      .then((data: ChangelogData) => setChangelog(data))
+      .catch((err) => console.error('Failed to load changelog', err));
+
+    fetch(`${API_BASE_URL}/api/version`)
+      .then((res) => res.json())
+      .then((data: ApiVersion) => setApiVersion(data))
+      .catch((err) => console.error('Failed to load API version', err));
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="border-b">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-3">
+          <Link to="/">
+            <Button variant="ghost" size="icon" aria-label="Back to home">
+              <ArrowLeft className="w-5 h-5" />
+            </Button>
+          </Link>
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-primary" />
+            <h1 className="text-xl font-semibold">What's New</h1>
+          </div>
+        </div>
+        <div className="max-w-2xl mx-auto px-4 pb-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+          <div
+            className="flex items-center gap-1.5"
+            title={`SHA: ${frontendVersion.gitSha}\nBuilt: ${frontendVersion.buildTime}`}
+          >
+            <Monitor className="w-3.5 h-3.5" />
+            <span>Web:</span>
+            <code className="bg-muted px-1.5 py-0.5 rounded font-mono">{frontendVersion.version}</code>
+          </div>
+          <div
+            className="flex items-center gap-1.5"
+            title={apiVersion ? `SHA: ${apiVersion.gitSha}\nBuilt: ${apiVersion.buildTime}` : ''}
+          >
+            <Server className="w-3.5 h-3.5" />
+            <span>API:</span>
+            <code className="bg-muted px-1.5 py-0.5 rounded font-mono">{apiVersion?.version || '...'}</code>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 max-w-2xl w-full mx-auto px-4 py-6">
+        <ChangelogList autoLoad={false} changelog={changelog} />
+      </main>
+    </div>
+  );
+}

--- a/nestle-together/src/pages/Index.tsx
+++ b/nestle-together/src/pages/Index.tsx
@@ -1,12 +1,8 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Users, Sparkles, Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { WhatsNewDialog } from '@/components/WhatsNewDialog';
 
 const Index = () => {
-  const [whatsNewOpen, setWhatsNewOpen] = useState(false);
-
   return (
     <div className="min-h-screen flex flex-col">
       {/* Hero Section */}
@@ -68,17 +64,14 @@ const Index = () => {
       {/* Footer */}
       <footer className="text-center py-6 text-sm text-muted-foreground space-y-2">
         <div>Made with 🍌 for families everywhere</div>
-        <button
-          type="button"
-          onClick={() => setWhatsNewOpen(true)}
+        <Link
+          to="/changelog"
           className="inline-flex items-center gap-1.5 text-xs hover:text-foreground transition-colors"
         >
           <Sparkles className="w-3.5 h-3.5" />
           What's New
-        </button>
+        </Link>
       </footer>
-
-      <WhatsNewDialog variant="controlled" open={whatsNewOpen} onOpenChange={setWhatsNewOpen} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Promotes the changelog from a modal-only experience to a full-page route at \`/changelog\`. The landing footer's "What's New" link (added in #49) now navigates there instead of opening the dialog.

The dialog still exists for in-app use (\`HouseholdDashboard\` header), but both surfaces now share a single \`ChangelogList\` component so they can't drift in look or behavior.

### Changes
- New \`pages/Changelog.tsx\` — back link, Web/API version chips, full list.
- New \`components/ChangelogList.tsx\` — extracted date-grouped rendering.
- \`WhatsNewDialog.tsx\` — slimmed down to use \`ChangelogList\` (kept the trigger variants, version header, and ScrollArea wrapper).
- \`Index.tsx\` — footer "What's New" is now a \`<Link to=\"/changelog\">\`, no modal state.
- \`App.tsx\` — registered the route above the catch-all.

## Test plan
- [ ] \`/\` → click "What's New" footer link → navigates to \`/changelog\` with the full list visible.
- [ ] Back arrow returns to \`/\`.
- [ ] In-app: \`/household/:id\` → "What's New" sparkles button still opens the modal with the same list (sanity check the shared component).
- [ ] Direct visit to \`/changelog\` (no auth) works.
- [ ] CI green.