### PR TITLE
feat(changelog): include full project history

### DIFF
--- a/nestle-together/scripts/generate-changelog.js
+++ b/nestle-together/scripts/generate-changelog.js
@@ -6,10 +6,11 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '../..');
 
-// Get recent commits from git
+// Pull the full project history. The /changelog page renders all of this;
+// the in-app WhatsNewDialog limits to a recent slice client-side.
 const gitLog = execSync(
-  'git log --oneline -50 --format="%H|%h|%s|%cs|%an"',
-  { cwd: repoRoot, encoding: 'utf-8' }
+  'git log --format="%H|%h|%s|%cs|%an"',
+  { cwd: repoRoot, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
 );
 
 const commits = gitLog
@@ -55,9 +56,7 @@ const commits = gitLog
       type,
       displayMessage: cleanMessage
     };
-  })
-  // Take last 20 user-facing changes
-  .slice(0, 20);
+  });
 
 const changelog = {
   generated: new Date().toISOString(),

--- a/nestle-together/src/components/ChangelogList.tsx
+++ b/nestle-together/src/components/ChangelogList.tsx
@@ -33,13 +33,15 @@ interface ChangelogListProps {
   autoLoad?: boolean;
   /** Inject pre-loaded changelog data. Wins over autoLoad. */
   changelog?: Changelog | null;
+  /** Cap the number of commits rendered. Undefined = render all. */
+  limit?: number;
 }
 
 /**
  * Renders the changelog as a date-grouped list. Used inside WhatsNewDialog
- * (modal) and on the /changelog page.
+ * (modal, with a small limit) and on the /changelog page (no limit).
  */
-export function ChangelogList({ autoLoad = true, changelog: injected }: ChangelogListProps) {
+export function ChangelogList({ autoLoad = true, changelog: injected, limit }: ChangelogListProps) {
   const [fetched, setFetched] = useState<Changelog | null>(null);
 
   useEffect(() => {
@@ -58,7 +60,8 @@ export function ChangelogList({ autoLoad = true, changelog: injected }: Changelo
     );
   }
 
-  const groupedByDate = data.commits.reduce((acc, commit) => {
+  const visible = limit !== undefined ? data.commits.slice(0, limit) : data.commits;
+  const groupedByDate = visible.reduce((acc, commit) => {
     const date = commit.date;
     if (!acc[date]) acc[date] = [];
     acc[date].push(commit);

--- a/nestle-together/src/components/WhatsNewDialog.tsx
+++ b/nestle-together/src/components/WhatsNewDialog.tsx
@@ -97,7 +97,7 @@ export function WhatsNewDialog({ variant = 'icon', open: controlledOpen, onOpenC
           </div>
         </DialogHeader>
         <ScrollArea className="h-[60vh] pr-4">
-          <ChangelogList autoLoad={false} changelog={changelog} />
+          <ChangelogList autoLoad={false} changelog={changelog} limit={20} />
         </ScrollArea>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
\`/changelog\` was only showing the last ~20 entries because the generator was double-capped: \`git log -50\` then \`.slice(0, 20)\` after filtering. Drop both so the page renders the entire history (203 entries today, ~66KB JSON gzipped down to a few KB).

The in-app \`WhatsNewDialog\` modal would look cluttered with everything, so \`ChangelogList\` now accepts an optional \`limit\` prop:
- \`/changelog\` page → no limit → full history.
- \`WhatsNewDialog\` modal → \`limit={20}\` → recent slice.

The generator runs as a prebuild step via \`npm run build\`, so the deploy regenerates \`public/changelog.json\` automatically. I did not commit the regenerated 66KB file — it would churn on every PR and adds nothing reviewable.

## Test plan
- [ ] \`/changelog\` on prod after deploy → scroll all the way down to the earliest commit ("Add gitignore" from 2026-01-31).
- [ ] In-app \`/household/:id\` → "What's New" sparkles → modal still shows ~20 most recent only.
- [ ] CI green.