### PR TITLE
feat(salary): per-line dates on slips + atomic chore-rate creation

### DIFF
--- a/ChoreMonkey.Core/Feature/Chores/Commands/AddChore/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Chores/Commands/AddChore/Handler.cs
@@ -8,24 +8,28 @@ using Microsoft.AspNetCore.Http;
 namespace ChoreMonkey.Core.Feature.Chores.Commands.AddChore;
 
 public record AddChoreCommand(
-    Guid HouseholdId, 
-    Guid ChoreId, 
-    string DisplayName, 
+    Guid HouseholdId,
+    Guid ChoreId,
+    string DisplayName,
     string Description,
     ChoreFrequency? Frequency = null,
     bool IsOptional = false,
     DateTime? StartDate = null,
     bool IsRequired = true,
-    decimal MissedDeduction = 10m);
+    decimal MissedDeduction = 10m,
+    decimal? DeductionRate = null,
+    decimal? BonusRate = null);
 
 public record AddChoreRequest(
-    string DisplayName, 
+    string DisplayName,
     string Description,
     FrequencyRequest? Frequency = null,
     bool IsOptional = false,
     DateTime? StartDate = null,
     bool IsRequired = true,
-    decimal MissedDeduction = 10m);
+    decimal MissedDeduction = 10m,
+    decimal? DeductionRate = null,
+    decimal? BonusRate = null);
 
 public record FrequencyRequest(
     string Type,
@@ -38,24 +42,39 @@ internal class Handler(IEventStore store)
 {
     public async Task<AddChoreResponse> HandleAsync(AddChoreCommand request)
     {
-        var streamId = ChoreAggregate.StreamId(request.HouseholdId);
-        
+        var choreStreamId = ChoreAggregate.StreamId(request.HouseholdId);
+
         // Default to "once" if no frequency specified
         var frequency = request.Frequency ?? new ChoreFrequency("once");
-        
+
         var choreCreated = new ChoreCreated(
-            request.ChoreId, 
-            request.HouseholdId, 
-            request.DisplayName, 
+            request.ChoreId,
+            request.HouseholdId,
+            request.DisplayName,
             request.Description,
             frequency,
             request.IsOptional,
             request.StartDate,
             request.IsRequired,
             request.MissedDeduction);
-            
-        await store.AppendToStreamAsync(streamId, choreCreated, ExpectedVersion.Any);
-        
+
+        await store.AppendToStreamAsync(choreStreamId, choreCreated, ExpectedVersion.Any);
+
+        // Atomic-from-the-client's-view rates write. Folded in to prevent the
+        // silent-drop bug where a separate /rates POST could fail and leave a
+        // bonus chore with no BonusRate (then GetCurrentPeriod falls back to 0).
+        if (request.DeductionRate.HasValue || request.BonusRate.HasValue)
+        {
+            var salaryStreamId = SalaryAggregate.StreamId(request.HouseholdId);
+            var ratesEvent = new ChoreRatesSet(
+                request.HouseholdId,
+                request.ChoreId,
+                request.DeductionRate,
+                request.BonusRate,
+                DateTime.UtcNow);
+            await store.AppendToStreamAsync(salaryStreamId, ratesEvent, ExpectedVersion.Any);
+        }
+
         return new AddChoreResponse(request.ChoreId);
     }
 }
@@ -66,22 +85,24 @@ internal static class AddChoreEndpoint
     {
         group.MapPost("households/{householdId:guid}/chores", async (Guid householdId, AddChoreRequest dto, Feature.Chores.Commands.AddChore.Handler handler) =>
         {
-            var frequency = dto.Frequency != null 
+            var frequency = dto.Frequency != null
                 ? new ChoreFrequency(dto.Frequency.Type, dto.Frequency.Days, dto.Frequency.IntervalDays)
                 : null;
-                
+
             var choreId = Guid.NewGuid();
             var command = new AddChoreCommand(
-                householdId, 
-                choreId, 
-                dto.DisplayName, 
+                householdId,
+                choreId,
+                dto.DisplayName,
                 dto.Description,
                 frequency,
                 dto.IsOptional,
                 dto.StartDate,
                 dto.IsRequired,
-                dto.MissedDeduction);
-                
+                dto.MissedDeduction,
+                dto.DeductionRate,
+                dto.BonusRate);
+
             var result = await handler.HandleAsync(command);
             return Results.Created($"/api/households/{householdId}/chores/{choreId}", result);
         });

--- a/ChoreMonkey.Core/Feature/Salary/Commands/ClosePeriod/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Salary/Commands/ClosePeriod/Handler.cs
@@ -168,7 +168,7 @@ internal class Handler(IEventStore store, ISender mediator)
                         foreach (var completion in completions)
                         {
                             var amount = bonusRate * bonusMultiplier;
-                            bonuses.Add(new PayoutBonus(choreId, chore.DisplayName, bonusRate, bonusMultiplier, amount));
+                            bonuses.Add(new PayoutBonus(choreId, chore.DisplayName, bonusRate, bonusMultiplier, amount, completion.CompletedAt));
                             bonusChoresDto.Add(new BonusChoreDto(choreId, chore.DisplayName, completion.CompletedAt, amount));
                             totalBonuses += amount;
                         }
@@ -188,7 +188,7 @@ internal class Handler(IEventStore store, ISender mediator)
                     foreach (var period in missed)
                     {
                         var amount = deductionRate * deductionMultiplier;
-                        deductions.Add(new PayoutDeduction(choreId, chore.DisplayName, deductionRate, deductionMultiplier, amount));
+                        deductions.Add(new PayoutDeduction(choreId, chore.DisplayName, deductionRate, deductionMultiplier, amount, period));
                         missedChoresDto.Add(new MissedChoreDto(choreId, chore.DisplayName, period, amount));
                         totalDeductions += amount;
                     }

--- a/ChoreMonkey.Core/Feature/Salary/Queries/GetOfficialSalarySlip/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Salary/Queries/GetOfficialSalarySlip/Handler.cs
@@ -13,13 +13,15 @@ public record DeductionLineDto(
     string ChoreName,
     decimal BaseRate,
     decimal Multiplier,
-    decimal Amount);
+    decimal Amount,
+    string? Period);
 
 public record BonusLineDto(
     string ChoreName,
     decimal BaseRate,
     decimal Multiplier,
-    decimal Amount);
+    decimal Amount,
+    DateTime? CompletedAt);
 
 public record OfficialSalarySlipResponse(
     Guid PeriodId,
@@ -63,12 +65,14 @@ internal class Handler(IEventStore store)
                 d.ChoreName,
                 d.BaseRate,
                 d.Multiplier,
-                d.Amount)).ToList(),
+                d.Amount,
+                d.Period)).ToList(),
             payout.Bonuses.Select(b => new BonusLineDto(
                 b.ChoreName,
                 b.BaseRate,
                 b.Multiplier,
-                b.Amount)).ToList(),
+                b.Amount,
+                b.CompletedAt)).ToList(),
             payout.GrossDeductions,
             payout.GrossBonuses,
             payout.NetPay);

--- a/ChoreMonkey.Events/PeriodClosed.cs
+++ b/ChoreMonkey.Events/PeriodClosed.cs
@@ -23,11 +23,13 @@ public record PayoutDeduction(
     string ChoreName,
     decimal BaseRate,
     decimal Multiplier,
-    decimal Amount);
+    decimal Amount,
+    string? Period = null);
 
 public record PayoutBonus(
     Guid ChoreId,
     string ChoreName,
     decimal BaseRate,
     decimal Multiplier,
-    decimal Amount);
+    decimal Amount,
+    DateTime? CompletedAt = null);

--- a/nestle-together/src/components/AddChoreDialog.tsx
+++ b/nestle-together/src/components/AddChoreDialog.tsx
@@ -23,8 +23,7 @@ import { Switch } from '@/components/ui/switch';
 import type { ChoreFrequency } from '@/types/household';
 
 interface AddChoreDialogProps {
-  onAdd: (displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number) => Promise<{ id: string } | null | void>;
-  onSetRates?: (choreId: string, deductionRate: number, bonusRate: number) => Promise<void>;
+  onAdd: (displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number, deductionRate?: number, bonusRate?: number) => Promise<{ id: string } | null | void>;
 }
 
 const DAYS_OF_WEEK = [
@@ -37,7 +36,7 @@ const DAYS_OF_WEEK = [
   { value: 'sunday', label: 'Sun' },
 ];
 
-export function AddChoreDialog({ onAdd, onSetRates }: AddChoreDialogProps) {
+export function AddChoreDialog({ onAdd }: AddChoreDialogProps) {
   const [open, setOpen] = useState(false);
   const [displayName, setDisplayName] = useState('');
   const [description, setDescription] = useState('');
@@ -70,19 +69,26 @@ export function AddChoreDialog({ onAdd, onSetRates }: AddChoreDialogProps) {
     const parsedStartDate = startDate ? new Date(startDate) : undefined;
     const deduction = parseFloat(missedDeduction) || 10;
     const bonus = parseFloat(bonusRate) || 10;
-    
-    const result = await onAdd(displayName.trim(), description.trim(), frequency, isOptional, parsedStartDate, isRequired, deduction);
-    
-    // Set salary rates if we got a chore ID back
-    if (result?.id && onSetRates) {
-      // Required chores have deductions, bonus chores have bonuses (mutually exclusive)
-      if (isOptional) {
-        await onSetRates(result.id, 0, bonus);
-      } else if (isRequired) {
-        await onSetRates(result.id, deduction, 0);
-      }
-    }
-    
+
+    // Rates are mutually exclusive: required chores get a deduction rate,
+    // optional/bonus chores get a bonus rate. Pass them with the create call
+    // so the server writes ChoreCreated + ChoreRatesSet in a single request —
+    // the old two-step flow could silently drop the rate.
+    const deductionForApi = !isOptional && isRequired ? deduction : undefined;
+    const bonusForApi = isOptional ? bonus : undefined;
+
+    await onAdd(
+      displayName.trim(),
+      description.trim(),
+      frequency,
+      isOptional,
+      parsedStartDate,
+      isRequired,
+      deduction,
+      deductionForApi,
+      bonusForApi,
+    );
+
     setIsSubmitting(false);
     setDisplayName('');
     setDescription('');

--- a/nestle-together/src/components/tabs/ChoresTab.tsx
+++ b/nestle-together/src/components/tabs/ChoresTab.tsx
@@ -15,13 +15,12 @@ interface ChoresTabProps {
   onCompleteChore: (chore: Chore | string) => void;
   onAssignChore: (choreId: string, memberIds?: string[], assignToAll?: boolean) => void;
   onDeleteChore: (choreId: string) => void;
-  onAddChore: (displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number) => Promise<{ id: string } | null>;
-  onSetChoreRates: (choreId: string, deductionRate: number, bonusRate: number) => Promise<void>;
+  onAddChore: (displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number, deductionRate?: number, bonusRate?: number) => Promise<{ id: string } | null>;
 }
 
 export function ChoresTab({
   householdId, currentMemberId, members, chores, refreshKey, isAdmin,
-  onCompleteChore, onAssignChore, onDeleteChore, onAddChore, onSetChoreRates,
+  onCompleteChore, onAssignChore, onDeleteChore, onAddChore,
 }: ChoresTabProps) {
   const isAssignedToMe = (chore: Chore) =>
     chore.assignedToAll || (chore.assignedTo?.includes(currentMemberId || '') ?? false);
@@ -37,7 +36,7 @@ export function ChoresTab({
           <ClipboardList className="w-5 h-5 text-primary" />
           <h2 className="font-bold text-lg">My Chores</h2>
         </div>
-        <AddChoreDialog onAdd={onAddChore} onSetRates={onSetChoreRates} />
+        <AddChoreDialog onAdd={onAddChore} />
       </div>
 
       {currentMemberId && (

--- a/nestle-together/src/features/chores/types.ts
+++ b/nestle-together/src/features/chores/types.ts
@@ -46,6 +46,11 @@ export interface AddChoreRequest {
   startDate?: string;
   isRequired?: boolean;
   missedDeduction?: number;
+  // Atomic rate-set on creation. The server appends ChoreRatesSet in the
+  // same handler — prevents the silent-drop bug where a separate /rates POST
+  // could fail and leave a bonus chore paying 0.
+  deductionRate?: number;
+  bonusRate?: number;
 }
 
 export interface AssignChoreRequest {

--- a/nestle-together/src/features/salary/components/SalarySlip.tsx
+++ b/nestle-together/src/features/salary/components/SalarySlip.tsx
@@ -17,6 +17,21 @@ export function SalarySlip({ slip, onClose, isPreview = false }: SalarySlipProps
 
   const formatCurrency = (amount: number) => `${amount.toFixed(2)} kr`;
 
+  // Period is either an ISO date ("2024-02-13") or a week token ("2024-W06").
+  // Render ISO dates in a short localized form; pass week tokens through unchanged.
+  const formatPeriod = (period: string | null) => {
+    if (!period) return '—';
+    if (/^\d{4}-\d{2}-\d{2}$/.test(period)) {
+      return new Date(period).toLocaleDateString('sv-SE', { month: 'short', day: 'numeric' });
+    }
+    return period;
+  };
+
+  const formatCompletedAt = (iso: string | null) => {
+    if (!iso) return '—';
+    return new Date(iso).toLocaleDateString('sv-SE', { month: 'short', day: 'numeric' });
+  };
+
   return (
     <div className="salary-slip-overlay" onClick={onClose}>
       <div className="salary-slip" onClick={(e) => e.stopPropagation()}>
@@ -41,6 +56,7 @@ export function SalarySlip({ slip, onClose, isPreview = false }: SalarySlipProps
                 <thead>
                   <tr>
                     <th>Chore</th>
+                    <th>Missed</th>
                     <th>Rate</th>
                     <th>Mult.</th>
                     <th>Amount</th>
@@ -50,6 +66,7 @@ export function SalarySlip({ slip, onClose, isPreview = false }: SalarySlipProps
                   {slip.deductions.map((d, i) => (
                     <tr key={i}>
                       <td className="chore-name">{d.choreName}</td>
+                      <td className="slip-when">{formatPeriod(d.period)}</td>
                       <td>{d.baseRate.toFixed(2)}</td>
                       <td>{d.multiplier.toFixed(1)}x</td>
                       <td>-{formatCurrency(d.amount)}</td>
@@ -69,6 +86,7 @@ export function SalarySlip({ slip, onClose, isPreview = false }: SalarySlipProps
                 <thead>
                   <tr>
                     <th>Chore</th>
+                    <th>Done</th>
                     <th>Rate</th>
                     <th>Mult.</th>
                     <th>Amount</th>
@@ -78,6 +96,7 @@ export function SalarySlip({ slip, onClose, isPreview = false }: SalarySlipProps
                   {slip.bonuses.map((b, i) => (
                     <tr key={i}>
                       <td className="chore-name">{b.choreName}</td>
+                      <td className="slip-when">{formatCompletedAt(b.completedAt)}</td>
                       <td>{b.baseRate.toFixed(2)}</td>
                       <td>{b.multiplier.toFixed(1)}x</td>
                       <td>+{formatCurrency(b.amount)}</td>

--- a/nestle-together/src/features/salary/types.ts
+++ b/nestle-together/src/features/salary/types.ts
@@ -74,6 +74,7 @@ export interface SlipDeduction {
   baseRate: number;
   multiplier: number;
   amount: number;
+  period: string | null;
 }
 
 export interface SlipBonus {
@@ -81,6 +82,7 @@ export interface SlipBonus {
   baseRate: number;
   multiplier: number;
   amount: number;
+  completedAt: string | null;
 }
 
 export interface AvailablePeriod {

--- a/nestle-together/src/features/store.ts
+++ b/nestle-together/src/features/store.ts
@@ -52,7 +52,7 @@ interface AppState {
   
   // Chores
   getHouseholdChores: (householdId: string) => Promise<Chore[]>;
-  addChore: (householdId: string, displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number) => Promise<Chore | null>;
+  addChore: (householdId: string, displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number, deductionRate?: number, bonusRate?: number) => Promise<Chore | null>;
   completeChore: (householdId: string, choreId: string, memberId: string, completedAt?: Date) => Promise<void>;
   assignChore: (householdId: string, choreId: string, memberIds?: string[], assignToAll?: boolean) => Promise<void>;
   deleteChore: (householdId: string, choreId: string) => Promise<boolean>;
@@ -230,7 +230,7 @@ export const useAppStore = create<AppState>()(
 
       getHouseholdChores: (householdId) => choresApi.fetchChores(householdId),
 
-      addChore: async (householdId, displayName, description, frequency, isOptional, startDate, isRequired = true, missedDeduction = 10) => {
+      addChore: async (householdId, displayName, description, frequency, isOptional, startDate, isRequired = true, missedDeduction = 10, deductionRate, bonusRate) => {
         try {
           const choreId = crypto.randomUUID();
           await choresApi.addChore(householdId, {
@@ -242,6 +242,8 @@ export const useAppStore = create<AppState>()(
             startDate: startDate?.toISOString(),
             isRequired,
             missedDeduction,
+            deductionRate,
+            bonusRate,
           });
 
           // Return a minimal chore object - full data comes from refresh

--- a/nestle-together/src/hooks/useHouseholdActions.ts
+++ b/nestle-together/src/hooks/useHouseholdActions.ts
@@ -15,10 +15,11 @@ export function useHouseholdActions({ household, chores, setChores, bumpRefreshK
 
   const handleAddChore = useCallback(async (
     displayName: string, description: string, frequency?: ChoreFrequency,
-    isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number
+    isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number,
+    deductionRate?: number, bonusRate?: number
   ) => {
     if (!household) return null;
-    const newChore = await addChore(household.id, displayName, description, frequency, isOptional, startDate, isRequired, missedDeduction);
+    const newChore = await addChore(household.id, displayName, description, frequency, isOptional, startDate, isRequired, missedDeduction, deductionRate, bonusRate);
     if (newChore) {
       setChores((prev) => [...prev, newChore]);
       bumpRefreshKey();

--- a/nestle-together/src/pages/HouseholdDashboard.tsx
+++ b/nestle-together/src/pages/HouseholdDashboard.tsx
@@ -166,7 +166,6 @@ export default function HouseholdDashboard() {
             onAssignChore={actions.handleAssignChore}
             onDeleteChore={actions.handleDeleteChore}
             onAddChore={actions.handleAddChore}
-            onSetChoreRates={actions.handleSetChoreRates}
           />
         )}
         {activeTab === 'team' && (


### PR DESCRIPTION
Two related changes to the salary surface, kept as separate commits.

## Summary

**1. `feat(salary): show per-line dates on salary slips`** — Each deduction line now carries the date the chore was missed; each bonus line carries the completion timestamp. Surfaces info that was already computed during period close but discarded by the `PeriodClosed` event.

**2. `fix(chores): set chore rates atomically with create`** — The bonus-not-registering bug. `AddChoreDialog` used to POST `/chores` then separately POST `…/chores/{id}/rates`. The second call returned a bool nobody checked, so any failure silently dropped the rate event — and `GetCurrentPeriod` falls back to `BonusRate ?? 0`, so the bonus chore paid 0 even though the UI showed a 10 kr default. Rates now ride on the create command and the server appends `ChoreRatesSet` in the same handler.

## Event-schema compatibility

`PayoutDeduction.Period` and `PayoutBonus.CompletedAt` are added as **nullable with default `null`**, so existing persisted `PeriodClosed` events deserialize cleanly; old slips render the new columns as an em dash.

`AddChoreRequest`'s new `DeductionRate` / `BonusRate` are also nullable with default `null` — old clients keep working with the previous two-step flow (the standalone `SetChoreRates` endpoint stays for admin edits).

## Test plan

- [ ] Create a bonus chore via the dialog → confirm `ChoreRatesSet` is appended in the same request (network tab: only one POST to `/chores`, no `/rates` follow-up).
- [ ] Complete that bonus chore → confirm the bonus shows up on the current-period view at the right kr value (not 0).
- [ ] Close a period that has at least one missed chore → confirm the slip's Deductions table shows a "Missed" column with the date, and Bonuses table shows a "Done" column with the completion date.
- [ ] Open an OLD slip (from before this PR) → confirm it still renders, with em dashes in the new columns.
- [ ] `dotnet test ChoreMonkey.IntegrationTests` passes (couldn't run locally — NuGet auth issue with FileEventStore feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)