### PR TITLE
feat(chores): pause a chore over a date range to exempt missed instances

### DIFF
--- a/ChoreMonkey.Core/Domain/ChorePauses.cs
+++ b/ChoreMonkey.Core/Domain/ChorePauses.cs
@@ -1,0 +1,46 @@
+using ChoreMonkey.Events;
+
+namespace ChoreMonkey.Core.Domain;
+
+/// <summary>
+/// A resolved pause window for a chore. Dates are compared inclusively at
+/// day granularity — a chore is paused on any date from Start through End.
+/// </summary>
+public record PauseWindow(Guid PauseId, DateTime Start, DateTime End, string? Reason = null)
+{
+    public bool Covers(DateTime date) => date.Date >= Start.Date && date.Date <= End.Date;
+}
+
+/// <summary>
+/// Builds the set of active pause windows per chore from the chore event stream,
+/// honoring <see cref="ChorePauseRemoved"/>, and exposes the checks used by the
+/// overdue/penalty calculators. A missed instance whose reference date falls in
+/// any active window is exempt (no overdue display, no salary deduction).
+/// </summary>
+public static class ChorePauses
+{
+    /// <summary>choreId → active (non-removed) pause windows.</summary>
+    public static Dictionary<Guid, List<PauseWindow>> Build(IEnumerable<object> choreEvents)
+    {
+        var events = choreEvents.ToList();
+
+        var removed = events.OfType<ChorePauseRemoved>()
+            .Select(e => e.PauseId)
+            .ToHashSet();
+
+        return events.OfType<ChorePaused>()
+            .Where(e => !removed.Contains(e.PauseId))
+            .GroupBy(e => e.ChoreId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => new PauseWindow(e.PauseId, e.PauseStart, e.PauseEnd, e.Reason)).ToList());
+    }
+
+    /// <summary>True when <paramref name="date"/> falls within any window.</summary>
+    public static bool CoversDate(this List<PauseWindow>? pauses, DateTime date)
+        => pauses != null && pauses.Any(w => w.Covers(date));
+
+    /// <summary>True when any date in [start, end] (inclusive) falls within any window.</summary>
+    public static bool CoversAnyInRange(this List<PauseWindow>? pauses, DateTime startInclusive, DateTime endInclusive)
+        => pauses != null && pauses.Any(w => w.Start.Date <= endInclusive.Date && w.End.Date >= startInclusive.Date);
+}

--- a/ChoreMonkey.Core/Feature/Activity/Queries/TeamOverview/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Activity/Queries/TeamOverview/Handler.cs
@@ -86,7 +86,10 @@ internal class Handler(IEventStore store, ISender mediator)
         var assignments = choreEvents.OfType<ChoreAssigned>()
             .GroupBy(e => e.ChoreId)
             .ToDictionary(g => g.Key, g => g.Last());
-        
+
+        // Active pause windows per chore — a missed instance within a window isn't overdue.
+        var chorePauses = ChorePauses.Build(choreEvents);
+
         // Get completions grouped by chore and member
         var completions = choreEvents.OfType<ChoreCompleted>()
             .GroupBy(e => (e.ChoreId, e.CompletedByMemberId))
@@ -119,11 +122,12 @@ internal class Handler(IEventStore store, ISender mediator)
                 
                 // Calculate status
                 var (status, overduePeriod) = CalculateStatus(
-                    chore.Frequency, 
-                    lastCompletedAt, 
-                    today, 
+                    chore.Frequency,
+                    lastCompletedAt,
+                    today,
                     choreStartDate,
-                    chore.IsOptional);
+                    chore.IsOptional,
+                    chorePauses.GetValueOrDefault(choreId));
                 
                 choreStatuses.Add(new ChoreStatusDto(
                     choreId,
@@ -158,38 +162,39 @@ internal class Handler(IEventStore store, ISender mediator)
     }
     
     private static (string Status, string? OverduePeriod) CalculateStatus(
-        ChoreFrequency? frequency, 
-        DateTime? lastCompleted, 
+        ChoreFrequency? frequency,
+        DateTime? lastCompleted,
         DateTime today,
         DateTime choreStartDate,
-        bool isOptional)
+        bool isOptional,
+        List<PauseWindow>? pauses)
     {
         if (frequency == null || frequency.Type.ToLower() == "once")
         {
             // One-time chore: completed if ever done
             return lastCompleted != null ? ("completed", null) : ("pending", null);
         }
-        
+
         // Check if completed this period
         var completedThisPeriod = IsCompletedThisPeriod(frequency, lastCompleted, today);
         if (completedThisPeriod)
         {
             return ("completed", null);
         }
-        
+
         // Optional chores can't be overdue
         if (isOptional)
         {
             return ("pending", null);
         }
-        
+
         // Check if overdue
-        var overduePeriod = CalculateOverduePeriod(frequency, lastCompleted, today, choreStartDate);
+        var overduePeriod = CalculateOverduePeriod(frequency, lastCompleted, today, choreStartDate, pauses);
         if (overduePeriod != null)
         {
             return ("overdue", overduePeriod);
         }
-        
+
         return ("pending", null);
     }
     
@@ -206,27 +211,28 @@ internal class Handler(IEventStore store, ISender mediator)
         };
     }
     
-    private static string? CalculateOverduePeriod(ChoreFrequency? frequency, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+    private static string? CalculateOverduePeriod(ChoreFrequency? frequency, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         if (frequency == null) return null;
-        
+
         return frequency.Type.ToLower() switch
         {
-            "daily" => CalculateDailyOverdue(lastCompleted, today, choreCreatedAt),
-            "weekly" => CalculateWeeklyOverdue(frequency.Days, lastCompleted, today, choreCreatedAt),
-            "interval" => CalculateIntervalOverdue(frequency.IntervalDays ?? 1, lastCompleted, today, choreCreatedAt),
+            "daily" => CalculateDailyOverdue(lastCompleted, today, choreCreatedAt, pauses),
+            "weekly" => CalculateWeeklyOverdue(frequency.Days, lastCompleted, today, choreCreatedAt, pauses),
+            "interval" => CalculateIntervalOverdue(frequency.IntervalDays ?? 1, lastCompleted, today, choreCreatedAt, pauses),
             _ => null
         };
     }
-    
-    private static string? CalculateDailyOverdue(DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+
+    private static string? CalculateDailyOverdue(DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         var yesterday = today.AddDays(-1);
-        
+
         if (choreCreatedAt > yesterday) return null;
         if (lastCompleted?.Date >= today) return null;
         if (lastCompleted?.Date >= yesterday) return null;
-        
+        if (pauses.CoversDate(yesterday)) return null;
+
         return "yesterday";
     }
     
@@ -236,41 +242,43 @@ internal class Handler(IEventStore store, ISender mediator)
         return date.AddDays(-diff).Date;
     }
 
-    private static string? CalculateWeeklyOverdue(string[]? days, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+    private static string? CalculateWeeklyOverdue(string[]? days, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         var currentWeekStart = GetMondayOfWeek(today);
         var previousWeekStart = currentWeekStart.AddDays(-7);
-        
+
         if (days == null || days.Length == 0)
         {
             if (choreCreatedAt >= previousWeekStart) return null;
             if (lastCompleted?.Date >= currentWeekStart) return null;
             if (lastCompleted?.Date >= previousWeekStart) return null;
+            if (pauses.CoversAnyInRange(previousWeekStart, currentWeekStart.AddDays(-1))) return null;
             return "last week";
         }
-        
+
         var requiredDays = days
             .Select(d => Enum.Parse<DayOfWeek>(d, ignoreCase: true))
             .ToHashSet();
-        
+
         for (int i = 0; i < 7; i++)
         {
             var checkDate = previousWeekStart.AddDays(i);
-            
+
             if (!requiredDays.Contains(checkDate.DayOfWeek)) continue;
             if (choreCreatedAt > checkDate) continue;
             if (lastCompleted?.Date >= checkDate) return null;
-            
+            if (pauses.CoversDate(checkDate)) continue;
+
             return $"last {checkDate.DayOfWeek}";
         }
-        
+
         return null;
     }
-    
-    private static string? CalculateIntervalOverdue(int intervalDays, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+
+    private static string? CalculateIntervalOverdue(int intervalDays, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         DateTime dueDate;
-        
+
         if (lastCompleted == null)
         {
             dueDate = choreCreatedAt.AddDays(intervalDays);
@@ -279,13 +287,14 @@ internal class Handler(IEventStore store, ISender mediator)
         {
             dueDate = lastCompleted.Value.Date.AddDays(intervalDays);
         }
-        
+
         if (today <= dueDate) return null;
-        
+        if (pauses.CoversDate(dueDate)) return null;
+
         var daysOverdue = (int)(today - dueDate).TotalDays;
-        
+
         if (daysOverdue > intervalDays) return null;
-        
+
         if (daysOverdue == 1) return "yesterday";
         return $"{daysOverdue} days ago";
     }

--- a/ChoreMonkey.Core/Feature/Chores/Commands/PauseChore/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Chores/Commands/PauseChore/Handler.cs
@@ -1,0 +1,114 @@
+using ChoreMonkey.Core.Domain;
+using ChoreMonkey.Core.Security;
+using ChoreMonkey.Events;
+using FileEventStore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace ChoreMonkey.Core.Feature.Chores.Commands.PauseChore;
+
+public record PauseChoreCommand(
+    Guid HouseholdId,
+    Guid ChoreId,
+    Guid PauseId,
+    DateTime PauseStart,
+    DateTime PauseEnd,
+    string? Reason,
+    int PinCode);
+
+public record PauseChoreRequest(
+    DateTime PauseStart,
+    DateTime PauseEnd,
+    int PinCode,
+    string? Reason = null,
+    Guid? PauseId = null);
+
+public record PauseChoreResponse(Guid PauseId);
+
+internal class Handler(IEventStore store)
+{
+    public async Task<(bool IsAdmin, bool Success, string? Error, Guid PauseId)> HandleAsync(PauseChoreCommand request)
+    {
+        var householdStreamId = HouseholdAggregate.StreamId(request.HouseholdId);
+        var choreStreamId = ChoreAggregate.StreamId(request.HouseholdId);
+
+        var householdEvents = await store.FetchEventsAsync(householdStreamId);
+        var householdCreated = householdEvents.OfType<HouseholdCreated>().FirstOrDefault();
+        if (householdCreated == null)
+        {
+            return (false, false, "Household not found", Guid.Empty);
+        }
+
+        var adminPinHash = householdEvents.OfType<AdminPinChanged>()
+            .LastOrDefault()?.NewPinHash ?? householdCreated.PinHash;
+        if (!PinHasher.VerifyPin(request.PinCode, adminPinHash))
+        {
+            return (false, false, "Admin access required", Guid.Empty);
+        }
+
+        // Normalize to whole days; pause windows are inclusive of both ends.
+        var start = request.PauseStart.Date;
+        var end = request.PauseEnd.Date;
+        if (end < start)
+        {
+            return (true, false, "Pause end date must be on or after the start date", Guid.Empty);
+        }
+
+        var choreEvents = await store.FetchEventsAsync(choreStreamId);
+        var deletedChoreIds = choreEvents.OfType<ChoreDeleted>().Select(e => e.ChoreId).ToHashSet();
+        var choreExists = choreEvents.OfType<ChoreCreated>()
+            .Any(c => c.ChoreId == request.ChoreId && !deletedChoreIds.Contains(c.ChoreId));
+        if (!choreExists)
+        {
+            return (true, false, "Chore not found", Guid.Empty);
+        }
+
+        var pauseId = request.PauseId == Guid.Empty ? Guid.NewGuid() : request.PauseId;
+
+        var paused = new ChorePaused(
+            pauseId,
+            request.ChoreId,
+            request.HouseholdId,
+            start,
+            end,
+            string.IsNullOrWhiteSpace(request.Reason) ? null : request.Reason.Trim());
+
+        await store.AppendToStreamAsync(choreStreamId, paused, ExpectedVersion.Any);
+
+        return (true, true, null, pauseId);
+    }
+}
+
+internal static class PauseChoreEndpoint
+{
+    public static void Map(this RouteGroupBuilder group)
+    {
+        group.MapPost("households/{householdId:guid}/chores/{choreId:guid}/pause",
+            async (Guid householdId, Guid choreId, PauseChoreRequest dto, Handler handler) =>
+        {
+            var command = new PauseChoreCommand(
+                householdId,
+                choreId,
+                dto.PauseId ?? Guid.NewGuid(),
+                dto.PauseStart,
+                dto.PauseEnd,
+                dto.Reason,
+                dto.PinCode);
+
+            var (isAdmin, success, error, pauseId) = await handler.HandleAsync(command);
+
+            if (!isAdmin)
+            {
+                return Results.StatusCode(403);
+            }
+
+            if (!success)
+            {
+                return Results.BadRequest(new { error });
+            }
+
+            return Results.Ok(new PauseChoreResponse(pauseId));
+        });
+    }
+}

--- a/ChoreMonkey.Core/Feature/Chores/Commands/RemoveChorePause/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Chores/Commands/RemoveChorePause/Handler.cs
@@ -1,0 +1,77 @@
+using ChoreMonkey.Core.Domain;
+using ChoreMonkey.Core.Security;
+using ChoreMonkey.Events;
+using FileEventStore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace ChoreMonkey.Core.Feature.Chores.Commands.RemoveChorePause;
+
+public record RemoveChorePauseCommand(Guid HouseholdId, Guid ChoreId, Guid PauseId, int PinCode);
+public record RemoveChorePauseRequest(int PinCode);
+public record RemoveChorePauseResponse(bool Success);
+
+internal class Handler(IEventStore store)
+{
+    public async Task<(bool IsAdmin, bool Success)> HandleAsync(RemoveChorePauseCommand request)
+    {
+        var householdStreamId = HouseholdAggregate.StreamId(request.HouseholdId);
+        var choreStreamId = ChoreAggregate.StreamId(request.HouseholdId);
+
+        var householdEvents = await store.FetchEventsAsync(householdStreamId);
+        var householdCreated = householdEvents.OfType<HouseholdCreated>().FirstOrDefault();
+        if (householdCreated == null)
+        {
+            return (false, false);
+        }
+
+        var adminPinHash = householdEvents.OfType<AdminPinChanged>()
+            .LastOrDefault()?.NewPinHash ?? householdCreated.PinHash;
+        if (!PinHasher.VerifyPin(request.PinCode, adminPinHash))
+        {
+            return (false, false);
+        }
+
+        var choreEvents = await store.FetchEventsAsync(choreStreamId);
+
+        // Idempotent: only an active (created, not-yet-removed) pause can be removed.
+        var pauses = ChorePauses.Build(choreEvents);
+        var isActive = pauses.TryGetValue(request.ChoreId, out var windows)
+            && windows.Any(w => w.PauseId == request.PauseId);
+        if (!isActive)
+        {
+            return (true, false);
+        }
+
+        var removed = new ChorePauseRemoved(request.PauseId, request.ChoreId, request.HouseholdId);
+        await store.AppendToStreamAsync(choreStreamId, removed, ExpectedVersion.Any);
+
+        return (true, true);
+    }
+}
+
+internal static class RemoveChorePauseEndpoint
+{
+    public static void Map(this RouteGroupBuilder group)
+    {
+        group.MapPost("households/{householdId:guid}/chores/{choreId:guid}/pause/{pauseId:guid}/remove",
+            async (Guid householdId, Guid choreId, Guid pauseId, RemoveChorePauseRequest dto, Handler handler) =>
+        {
+            var command = new RemoveChorePauseCommand(householdId, choreId, pauseId, dto.PinCode);
+            var (isAdmin, success) = await handler.HandleAsync(command);
+
+            if (!isAdmin)
+            {
+                return Results.StatusCode(403);
+            }
+
+            if (!success)
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(new RemoveChorePauseResponse(true));
+        });
+    }
+}

--- a/ChoreMonkey.Core/Feature/Chores/Queries/ChoreList/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Chores/Queries/ChoreList/Handler.cs
@@ -25,7 +25,14 @@ public record ChoreDto(
     bool IsRequired = true,
     decimal MissedDeduction = 10m,
     decimal? DeductionRate = null,
-    decimal? BonusRate = null);
+    decimal? BonusRate = null,
+    List<PauseWindowDto>? Pauses = null);
+
+public record PauseWindowDto(
+    Guid PauseId,
+    DateTime Start,
+    DateTime End,
+    string? Reason);
 
 public record MemberCompletionDto(
     Guid MemberId,
@@ -95,6 +102,9 @@ internal class Handler(IEventStore store)
             .GroupBy(e => e.ChoreId)
             .ToDictionary(g => g.Key, g => g.Last());
 
+        // Active pause windows per chore
+        var chorePauses = ChorePauses.Build(events);
+
         // Get all completions grouped by chore
         var completionsByChore = events.OfType<ChoreCompleted>()
             .GroupBy(e => e.ChoreId)
@@ -106,8 +116,13 @@ internal class Handler(IEventStore store)
                 var choreCompletions = completionsByChore.GetValueOrDefault(e.ChoreId) ?? new List<ChoreCompleted>();
                 var lastCompletion = choreCompletions.OrderByDescending(c => c.CompletedAt).FirstOrDefault();
                 var rates = choreRates.GetValueOrDefault(e.ChoreId);
-                
-                var frequency = e.Frequency != null 
+
+                var pauses = chorePauses.GetValueOrDefault(e.ChoreId)
+                    ?.OrderBy(p => p.Start)
+                    .Select(p => new PauseWindowDto(p.PauseId, p.Start, p.End, p.Reason))
+                    .ToList();
+
+                var frequency = e.Frequency != null
                     ? new FrequencyDto(e.Frequency.Type, e.Frequency.Days, e.Frequency.IntervalDays)
                     : new FrequencyDto("once");
                 
@@ -151,7 +166,8 @@ internal class Handler(IEventStore store)
                     e.IsRequired,
                     e.MissedDeduction,
                     rates?.DeductionRate,
-                    rates?.BonusRate);
+                    rates?.BonusRate,
+                    pauses);
             })
             .ToList();
 

--- a/ChoreMonkey.Core/Feature/Chores/Queries/MyChores/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Chores/Queries/MyChores/Handler.cs
@@ -74,7 +74,10 @@ internal class Handler(IEventStore store)
         var assignments = choreEvents.OfType<ChoreAssigned>()
             .GroupBy(e => e.ChoreId)
             .ToDictionary(g => g.Key, g => g.Last());
-        
+
+        // Active pause windows per chore — a missed instance within a window isn't overdue.
+        var chorePauses = ChorePauses.Build(choreEvents);
+
         // Get this member's completions
         var myCompletions = choreEvents.OfType<ChoreCompleted>()
             .Where(c => c.CompletedByMemberId == request.MemberId)
@@ -166,7 +169,8 @@ internal class Handler(IEventStore store)
                     yesterday,
                     currentWeekStart,
                     previousWeekStart,
-                    choreStartDate);
+                    choreStartDate,
+                    chorePauses.GetValueOrDefault(choreId));
                 
                 if (overdueResult.IsOverdue)
                 {
@@ -241,82 +245,94 @@ internal class Handler(IEventStore store)
         DateTime yesterday,
         DateTime currentWeekStart,
         DateTime previousWeekStart,
-        DateTime choreStartDate)
+        DateTime choreStartDate,
+        List<PauseWindow>? pauses)
     {
         if (frequency == null || frequency.Type.ToLower() == "once")
         {
             return new OverdueResult(false, null, null);
         }
-        
+
         return frequency.Type.ToLower() switch
         {
-            "daily" => GetDailyOverdue(completions, acknowledgedPeriods, yesterday, choreStartDate),
-            "weekly" => GetWeeklyOverdue(frequency.Days, completions, acknowledgedPeriods, currentWeekStart, previousWeekStart, choreStartDate),
-            "interval" => GetIntervalOverdue(frequency.IntervalDays ?? 1, completions, acknowledgedPeriods, today, choreStartDate),
+            "daily" => GetDailyOverdue(completions, acknowledgedPeriods, yesterday, choreStartDate, pauses),
+            "weekly" => GetWeeklyOverdue(frequency.Days, completions, acknowledgedPeriods, currentWeekStart, previousWeekStart, choreStartDate, pauses),
+            "interval" => GetIntervalOverdue(frequency.IntervalDays ?? 1, completions, acknowledgedPeriods, today, choreStartDate, pauses),
             _ => new OverdueResult(false, null, null)
         };
     }
-    
+
     private static OverdueResult GetDailyOverdue(
         List<ChoreCompleted> completions,
         HashSet<string> acknowledgedPeriods,
         DateTime yesterday,
-        DateTime choreStartDate)
+        DateTime choreStartDate,
+        List<PauseWindow>? pauses)
     {
         // Can't be overdue if chore didn't exist yesterday
         if (choreStartDate > yesterday)
             return new OverdueResult(false, null, null);
-        
+
         var periodKey = yesterday.ToString("yyyy-MM-dd");
-        
+
         // Check if acknowledged
         if (acknowledgedPeriods.Contains(periodKey))
             return new OverdueResult(false, null, null);
-        
+
         // Check if completed yesterday
         var yesterdayCompletion = completions.FirstOrDefault(c => c.CompletedAt.Date == yesterday);
         if (yesterdayCompletion != null)
             return new OverdueResult(false, null, null);
-        
+
+        // Exempt if yesterday falls within a pause window
+        if (pauses.CoversDate(yesterday))
+            return new OverdueResult(false, null, null);
+
         return new OverdueResult(true, "yesterday", periodKey);
     }
-    
+
     private static OverdueResult GetWeeklyOverdue(
         string[]? days,
         List<ChoreCompleted> completions,
         HashSet<string> acknowledgedPeriods,
         DateTime currentWeekStart,
         DateTime previousWeekStart,
-        DateTime choreStartDate)
+        DateTime choreStartDate,
+        List<PauseWindow>? pauses)
     {
         // Can't be overdue if chore didn't exist last week
         if (choreStartDate >= currentWeekStart)
             return new OverdueResult(false, null, null);
-        
+
         var periodKey = GetWeekPeriod(previousWeekStart);
-        
+
         // Check if acknowledged
         if (acknowledgedPeriods.Contains(periodKey))
             return new OverdueResult(false, null, null);
-        
+
         // Check if completed last week
-        var lastWeekCompletion = completions.FirstOrDefault(c => 
+        var lastWeekCompletion = completions.FirstOrDefault(c =>
             c.CompletedAt.Date >= previousWeekStart && c.CompletedAt.Date < currentWeekStart);
         if (lastWeekCompletion != null)
             return new OverdueResult(false, null, null);
-        
+
+        // Exempt if a pause window overlaps last week
+        if (pauses.CoversAnyInRange(previousWeekStart, currentWeekStart.AddDays(-1)))
+            return new OverdueResult(false, null, null);
+
         return new OverdueResult(true, "last week", periodKey);
     }
-    
+
     private static OverdueResult GetIntervalOverdue(
         int intervalDays,
         List<ChoreCompleted> completions,
         HashSet<string> acknowledgedPeriods,
         DateTime today,
-        DateTime choreStartDate)
+        DateTime choreStartDate,
+        List<PauseWindow>? pauses)
     {
         var lastCompletion = completions.MaxBy(c => c.CompletedAt);
-        
+
         DateTime dueDate;
         if (lastCompletion == null)
         {
@@ -326,22 +342,26 @@ internal class Handler(IEventStore store)
         {
             dueDate = lastCompletion.CompletedAt.Date.AddDays(intervalDays);
         }
-        
+
         if (today <= dueDate)
             return new OverdueResult(false, null, null);
-        
+
         var daysOverdue = (int)(today - dueDate).TotalDays;
-        
+
         // Only show if within grace period (1 interval)
         if (daysOverdue > intervalDays)
             return new OverdueResult(false, null, null);
-        
+
         var periodKey = dueDate.ToString("yyyy-MM-dd");
-        
+
         // Check if acknowledged
         if (acknowledgedPeriods.Contains(periodKey))
             return new OverdueResult(false, null, null);
-        
+
+        // Exempt if the due date falls within a pause window
+        if (pauses.CoversDate(dueDate))
+            return new OverdueResult(false, null, null);
+
         var overduePeriod = daysOverdue == 1 ? "yesterday" : $"{daysOverdue} days ago";
         return new OverdueResult(true, overduePeriod, periodKey);
     }

--- a/ChoreMonkey.Core/Feature/Chores/Queries/OverdueChores/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Chores/Queries/OverdueChores/Handler.cs
@@ -78,7 +78,10 @@ internal class Handler(IEventStore store, ISender mediator)
         var assignments = choreEvents.OfType<ChoreAssigned>()
             .GroupBy(e => e.ChoreId)
             .ToDictionary(g => g.Key, g => g.Last());
-        
+
+        // Active pause windows per chore — a missed instance within a window isn't overdue.
+        var chorePauses = ChorePauses.Build(choreEvents);
+
         // Get completions grouped by chore and member
         var completions = choreEvents.OfType<ChoreCompleted>()
             .GroupBy(e => (e.ChoreId, e.CompletedByMemberId))
@@ -113,7 +116,7 @@ internal class Handler(IEventStore store, ISender mediator)
                     ?? (DateTime.TryParse(chore.TimestampUtc, out var parsed) ? parsed.Date : today);
                 
                 // Calculate if overdue within grace period
-                var overduePeriod = CalculateOverduePeriod(chore.Frequency, lastCompletedAt, today, choreStartDate);
+                var overduePeriod = CalculateOverduePeriod(chore.Frequency, lastCompletedAt, today, choreStartDate, chorePauses.GetValueOrDefault(choreId));
                 
                 if (overduePeriod != null)
                 {
@@ -139,28 +142,29 @@ internal class Handler(IEventStore store, ISender mediator)
                   .ToList());
     }
     
-    private static string? CalculateOverduePeriod(ChoreFrequency? frequency, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+    private static string? CalculateOverduePeriod(ChoreFrequency? frequency, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         if (frequency == null) return null;
-        
+
         return frequency.Type.ToLower() switch
         {
-            "daily" => CalculateDailyOverdue(lastCompleted, today, choreCreatedAt),
-            "weekly" => CalculateWeeklyOverdue(frequency.Days, lastCompleted, today, choreCreatedAt),
-            "interval" => CalculateIntervalOverdue(frequency.IntervalDays ?? 1, lastCompleted, today, choreCreatedAt),
+            "daily" => CalculateDailyOverdue(lastCompleted, today, choreCreatedAt, pauses),
+            "weekly" => CalculateWeeklyOverdue(frequency.Days, lastCompleted, today, choreCreatedAt, pauses),
+            "interval" => CalculateIntervalOverdue(frequency.IntervalDays ?? 1, lastCompleted, today, choreCreatedAt, pauses),
             "once" => null, // One-time chores can't be overdue
             _ => null
         };
     }
-    
-    private static string? CalculateDailyOverdue(DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+
+    private static string? CalculateDailyOverdue(DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         var yesterday = today.AddDays(-1);
-        
+
         if (choreCreatedAt > yesterday) return null;
         if (lastCompleted?.Date >= today) return null;
         if (lastCompleted?.Date >= yesterday) return null;
-        
+        if (pauses.CoversDate(yesterday)) return null;
+
         return "yesterday";
     }
     
@@ -170,41 +174,43 @@ internal class Handler(IEventStore store, ISender mediator)
         return date.AddDays(-diff).Date;
     }
 
-    private static string? CalculateWeeklyOverdue(string[]? days, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+    private static string? CalculateWeeklyOverdue(string[]? days, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         var currentWeekStart = GetMondayOfWeek(today);
         var previousWeekStart = currentWeekStart.AddDays(-7);
-        
+
         if (days == null || days.Length == 0)
         {
             if (choreCreatedAt >= previousWeekStart) return null;
             if (lastCompleted?.Date >= currentWeekStart) return null;
             if (lastCompleted?.Date >= previousWeekStart) return null;
+            if (pauses.CoversAnyInRange(previousWeekStart, currentWeekStart.AddDays(-1))) return null;
             return "last week";
         }
-        
+
         var requiredDays = days
             .Select(d => Enum.Parse<DayOfWeek>(d, ignoreCase: true))
             .ToHashSet();
-        
+
         for (int i = 0; i < 7; i++)
         {
             var checkDate = previousWeekStart.AddDays(i);
-            
+
             if (!requiredDays.Contains(checkDate.DayOfWeek)) continue;
             if (choreCreatedAt > checkDate) continue;
             if (lastCompleted?.Date >= checkDate) return null;
-            
+            if (pauses.CoversDate(checkDate)) continue;
+
             return $"last {checkDate.DayOfWeek}";
         }
-        
+
         return null;
     }
-    
-    private static string? CalculateIntervalOverdue(int intervalDays, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt)
+
+    private static string? CalculateIntervalOverdue(int intervalDays, DateTime? lastCompleted, DateTime today, DateTime choreCreatedAt, List<PauseWindow>? pauses)
     {
         DateTime dueDate;
-        
+
         if (lastCompleted == null)
         {
             dueDate = choreCreatedAt.AddDays(intervalDays);
@@ -213,13 +219,14 @@ internal class Handler(IEventStore store, ISender mediator)
         {
             dueDate = lastCompleted.Value.Date.AddDays(intervalDays);
         }
-        
+
         if (today <= dueDate) return null;
-        
+        if (pauses.CoversDate(dueDate)) return null;
+
         var daysOverdue = (int)(today - dueDate).TotalDays;
-        
+
         if (daysOverdue > intervalDays) return null;
-        
+
         if (daysOverdue == 1) return "yesterday";
         return $"{daysOverdue} days ago";
     }

--- a/ChoreMonkey.Core/Feature/Salary/Commands/ClosePeriod/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Salary/Commands/ClosePeriod/Handler.cs
@@ -118,6 +118,9 @@ internal class Handler(IEventStore store, ISender mediator)
             .GroupBy(e => e.ChoreId)
             .ToDictionary(g => g.Key, g => g.Last());
 
+        // Active pause windows per chore — missed instances within a window are exempt.
+        var chorePauses = ChorePauses.Build(choreEvents);
+
         // Get completions in period (end-exclusive)
         var completionsInPeriod = choreEvents
             .OfType<ChoreCompleted>()
@@ -178,11 +181,12 @@ internal class Handler(IEventStore store, ISender mediator)
                 {
                     // Required chores - calculate missed for entire period (no grace period when closing)
                     var missed = CalculateMissedInstances(
-                        chore, 
-                        lastCompletion?.CompletedAt, 
-                        periodStart, 
+                        chore,
+                        lastCompletion?.CompletedAt,
+                        periodStart,
                         periodEnd,
-                        completionsInPeriod.GetValueOrDefault((choreId, memberId)));
+                        completionsInPeriod.GetValueOrDefault((choreId, memberId)),
+                        chorePauses.GetValueOrDefault(choreId));
                     
                     var deductionRate = rates?.DeductionRate ?? chore.MissedDeduction;
                     foreach (var period in missed)
@@ -254,11 +258,12 @@ internal class Handler(IEventStore store, ISender mediator)
     }
 
     private List<string> CalculateMissedInstances(
-        ChoreCreated chore, 
-        DateTime? lastCompleted, 
+        ChoreCreated chore,
+        DateTime? lastCompleted,
         DateTime periodStart,
         DateTime periodEnd,
-        List<ChoreCompleted>? completionsInPeriod)
+        List<ChoreCompleted>? completionsInPeriod,
+        List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var frequency = chore.Frequency;
@@ -270,27 +275,27 @@ internal class Handler(IEventStore store, ISender mediator)
         switch (frequency.Type.ToLower())
         {
             case "daily":
-                missed = CalculateDailyMissed(effectiveStart, periodEnd, completionsInPeriod);
+                missed = CalculateDailyMissed(effectiveStart, periodEnd, completionsInPeriod, pauses);
                 break;
             case "weekly":
-                missed = CalculateWeeklyMissed(frequency.Days, effectiveStart, periodEnd, completionsInPeriod);
+                missed = CalculateWeeklyMissed(frequency.Days, effectiveStart, periodEnd, completionsInPeriod, pauses);
                 break;
             case "interval":
-                missed = CalculateIntervalMissed(frequency.IntervalDays ?? 1, effectiveStart, periodEnd, lastCompleted, completionsInPeriod);
+                missed = CalculateIntervalMissed(frequency.IntervalDays ?? 1, effectiveStart, periodEnd, lastCompleted, completionsInPeriod, pauses);
                 break;
         }
 
         return missed;
     }
 
-    private static List<string> CalculateDailyMissed(DateTime start, DateTime end, List<ChoreCompleted>? completions)
+    private static List<string> CalculateDailyMissed(DateTime start, DateTime end, List<ChoreCompleted>? completions, List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var completedDates = completions?.Select(c => c.CompletedAt.Date).ToHashSet() ?? new HashSet<DateTime>();
-        
+
         for (var date = start; date <= end; date = date.AddDays(1))
         {
-            if (!completedDates.Contains(date))
+            if (!completedDates.Contains(date) && !pauses.CoversDate(date))
             {
                 missed.Add(date.ToString("yyyy-MM-dd"));
             }
@@ -304,7 +309,7 @@ internal class Handler(IEventStore store, ISender mediator)
         return date.AddDays(-diff).Date;
     }
 
-    private static List<string> CalculateWeeklyMissed(string[]? days, DateTime start, DateTime end, List<ChoreCompleted>? completions)
+    private static List<string> CalculateWeeklyMissed(string[]? days, DateTime start, DateTime end, List<ChoreCompleted>? completions, List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var completedDates = completions?.Select(c => c.CompletedAt.Date).ToHashSet() ?? new HashSet<DateTime>();
@@ -313,13 +318,15 @@ internal class Handler(IEventStore store, ISender mediator)
         {
             var currentWeek = GetMondayOfWeek(start);
             var endWeek = GetMondayOfWeek(end);
-            
+
             while (currentWeek <= endWeek)
             {
                 var weekEnd = currentWeek.AddDays(6);
                 var completedThisWeek = completedDates.Any(d => d >= currentWeek && d <= weekEnd);
-                
-                if (!completedThisWeek)
+                // Exempt the week if a pause window overlaps any day of it.
+                var pausedThisWeek = pauses.CoversAnyInRange(currentWeek, weekEnd);
+
+                if (!completedThisWeek && !pausedThisWeek)
                 {
                     var weekNum = System.Globalization.CultureInfo.InvariantCulture.Calendar
                         .GetWeekOfYear(currentWeek, System.Globalization.CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
@@ -331,32 +338,32 @@ internal class Handler(IEventStore store, ISender mediator)
         else
         {
             var requiredDays = days.Select(d => Enum.Parse<DayOfWeek>(d, ignoreCase: true)).ToHashSet();
-            
+
             for (var date = start; date <= end; date = date.AddDays(1))
             {
-                if (requiredDays.Contains(date.DayOfWeek) && !completedDates.Contains(date))
+                if (requiredDays.Contains(date.DayOfWeek) && !completedDates.Contains(date) && !pauses.CoversDate(date))
                 {
                     missed.Add(date.ToString("yyyy-MM-dd"));
                 }
             }
         }
-        
+
         return missed;
     }
 
-    private static List<string> CalculateIntervalMissed(int intervalDays, DateTime start, DateTime end, DateTime? lastCompleted, List<ChoreCompleted>? completions)
+    private static List<string> CalculateIntervalMissed(int intervalDays, DateTime start, DateTime end, DateTime? lastCompleted, List<ChoreCompleted>? completions, List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var completedDates = completions?.Select(c => c.CompletedAt.Date).OrderBy(d => d).ToList() ?? new List<DateTime>();
-        
+
         var lastDue = lastCompleted?.Date ?? start.AddDays(-1);
         var idx = 0;
-        
+
         while (true)
         {
             var nextDue = lastDue.AddDays(intervalDays);
             if (nextDue > end) break;
-            
+
             while (idx < completedDates.Count && completedDates[idx] <= nextDue)
             {
                 lastDue = completedDates[idx];
@@ -364,13 +371,18 @@ internal class Handler(IEventStore store, ISender mediator)
                 nextDue = lastDue.AddDays(intervalDays);
                 if (nextDue > end) break;
             }
-            
+
             if (nextDue > end) break;
-            
-            missed.Add(nextDue.ToString("yyyy-MM-dd"));
+
+            // Advance the schedule past this due date regardless, but only record
+            // it as missed when the due date isn't within a pause window.
+            if (!pauses.CoversDate(nextDue))
+            {
+                missed.Add(nextDue.ToString("yyyy-MM-dd"));
+            }
             lastDue = nextDue;
         }
-        
+
         return missed;
     }
 }

--- a/ChoreMonkey.Core/Initialization.cs
+++ b/ChoreMonkey.Core/Initialization.cs
@@ -33,6 +33,8 @@ using ChoreMonkey.Core.Feature.Chores.Commands.CompleteChore;
 using ChoreMonkey.Core.Feature.Chores.Commands.DeleteChore;
 using ChoreMonkey.Core.Feature.Chores.Commands.UpdateChore;
 using ChoreMonkey.Core.Feature.Chores.Commands.AcknowledgeMissed;
+using ChoreMonkey.Core.Feature.Chores.Commands.PauseChore;
+using ChoreMonkey.Core.Feature.Chores.Commands.RemoveChorePause;
 using ChoreMonkey.Core.Feature.Chores.Queries.ChoreList;
 using ChoreMonkey.Core.Feature.Chores.Queries.ChoreHistory;
 using ChoreMonkey.Core.Feature.Chores.Queries.MyChores;
@@ -161,6 +163,8 @@ public static class Initialization
         services.AddScoped<Feature.Chores.Commands.DeleteChore.Handler>();
         services.AddScoped<Feature.Chores.Commands.UpdateChore.Handler>();
         services.AddScoped<Feature.Chores.Commands.AcknowledgeMissed.Handler>();
+        services.AddScoped<Feature.Chores.Commands.PauseChore.Handler>();
+        services.AddScoped<Feature.Chores.Commands.RemoveChorePause.Handler>();
         services.AddScoped<Feature.Chores.Queries.ChoreList.Handler>();
         services.AddScoped<Feature.Chores.Queries.ChoreHistory.Handler>();
         services.AddScoped<Feature.Chores.Queries.MyChores.Handler>();
@@ -226,6 +230,8 @@ public static class Initialization
         DeleteChoreEndpoint.Map(householdEndpoints);
         UpdateChoreEndpoint.Map(householdEndpoints);
         AcknowledgeMissedEndpoint.Map(householdEndpoints);
+        PauseChoreEndpoint.Map(householdEndpoints);
+        RemoveChorePauseEndpoint.Map(householdEndpoints);
         ChoreListEndpoint.Map(householdEndpoints);
         ChoreHistoryEndpoint.Map(householdEndpoints);
         MyChoresEndpoint.Map(householdEndpoints);

--- a/ChoreMonkey.Events/ChorePauseRemoved.cs
+++ b/ChoreMonkey.Events/ChorePauseRemoved.cs
@@ -1,0 +1,10 @@
+namespace ChoreMonkey.Events;
+
+/// <summary>
+/// Cancels a previously created pause window (by PauseId). After removal the
+/// window no longer exempts any missed instances.
+/// </summary>
+public record ChorePauseRemoved(
+    Guid PauseId,
+    Guid ChoreId,
+    Guid HouseholdId) : EventBase;

--- a/ChoreMonkey.Events/ChorePaused.cs
+++ b/ChoreMonkey.Events/ChorePaused.cs
@@ -1,0 +1,15 @@
+namespace ChoreMonkey.Events;
+
+/// <summary>
+/// A chore is paused for a date range. Missed instances that fall within
+/// [PauseStart, PauseEnd] (inclusive) don't count as overdue and incur no
+/// salary deduction. A chore can have multiple (even overlapping) pause
+/// windows; each is identified by PauseId so it can be removed independently.
+/// </summary>
+public record ChorePaused(
+    Guid PauseId,
+    Guid ChoreId,
+    Guid HouseholdId,
+    DateTime PauseStart,
+    DateTime PauseEnd,
+    string? Reason = null) : EventBase;

--- a/ChoreMonkey.IntegrationTests/Chores/ChorePauseTests.cs
+++ b/ChoreMonkey.IntegrationTests/Chores/ChorePauseTests.cs
@@ -1,0 +1,262 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace ChoreMonkey.IntegrationTests.Chores;
+
+/// <summary>
+/// Pausing a chore over a date range exempts any missed instances within that
+/// window: they don't show as overdue and they incur no salary deduction when
+/// the pay period is closed.
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public class ChorePauseTests(ApiFixture fixture)
+{
+    private readonly HttpClient _client = fixture.Client;
+    private const int AdminPin = 1234;
+
+    [Fact]
+    public async Task PauseChore_WithWrongPin_IsForbidden()
+    {
+        var household = await CreateHousehold("Pause Auth Family");
+        var choreId = await CreateDailyChore(household.HouseholdId, "Make Bed", startDaysAgo: 3);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/pause",
+            new { pauseStart = DateTime.UtcNow.AddDays(-2), pauseEnd = DateTime.UtcNow, pinCode = 9999 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task PauseChore_WithEndBeforeStart_IsBadRequest()
+    {
+        var household = await CreateHousehold("Pause Range Family");
+        var choreId = await CreateDailyChore(household.HouseholdId, "Make Bed", startDaysAgo: 3);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/pause",
+            new { pauseStart = DateTime.UtcNow, pauseEnd = DateTime.UtcNow.AddDays(-5), pinCode = AdminPin });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PausedDailyChore_IsNotOverdue()
+    {
+        // Arrange - a daily chore that's been overdue since yesterday
+        var household = await CreateHousehold("Vacation Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Away Kid");
+        var choreId = await CreateDailyChore(household.HouseholdId, "Feed Fish", startDaysAgo: 3);
+        await AssignChore(household.HouseholdId, choreId, kid.MemberId);
+
+        // Sanity: without a pause it IS overdue
+        var before = await GetOverdueChores(household.HouseholdId);
+        before.MemberOverdue.First(m => m.MemberId == kid.MemberId)
+            .Chores.Should().Contain(c => c.DisplayName == "Feed Fish");
+
+        // Act - pause covering yesterday
+        await PauseChore(household.HouseholdId, choreId, DateTime.UtcNow.AddDays(-2), DateTime.UtcNow);
+
+        // Assert - no longer overdue
+        var after = await GetOverdueChores(household.HouseholdId);
+        after.MemberOverdue.First(m => m.MemberId == kid.MemberId)
+            .Chores.Should().NotContain(c => c.DisplayName == "Feed Fish");
+    }
+
+    [Fact]
+    public async Task RemovingPause_RestoresOverdue()
+    {
+        var household = await CreateHousehold("Back From Vacation Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Back Kid");
+        var choreId = await CreateDailyChore(household.HouseholdId, "Water Plants", startDaysAgo: 3);
+        await AssignChore(household.HouseholdId, choreId, kid.MemberId);
+
+        var pauseId = await PauseChore(household.HouseholdId, choreId, DateTime.UtcNow.AddDays(-2), DateTime.UtcNow);
+
+        // Remove the pause
+        var removeResponse = await _client.PostAsJsonAsync(
+            $"/api/households/{household.HouseholdId}/chores/{choreId}/pause/{pauseId}/remove",
+            new { pinCode = AdminPin });
+        removeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Overdue again
+        var after = await GetOverdueChores(household.HouseholdId);
+        after.MemberOverdue.First(m => m.MemberId == kid.MemberId)
+            .Chores.Should().Contain(c => c.DisplayName == "Water Plants");
+    }
+
+    [Fact]
+    public async Task PausedChore_AppearsInChoreListWithWindow()
+    {
+        var household = await CreateHousehold("Pause Badge Family");
+        var choreId = await CreateDailyChore(household.HouseholdId, "Take Out Trash", startDaysAgo: 3);
+
+        var start = DateTime.UtcNow.Date.AddDays(-2);
+        var end = DateTime.UtcNow.Date;
+        await PauseChore(household.HouseholdId, choreId, start, end, reason: "Summer holiday");
+
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>(
+            $"/api/households/{household.HouseholdId}/chores");
+
+        var chore = chores!.Chores.First(c => c.ChoreId == choreId);
+        chore.Pauses.Should().ContainSingle();
+        chore.Pauses![0].Start.Date.Should().Be(start);
+        chore.Pauses[0].End.Date.Should().Be(end);
+        chore.Pauses[0].Reason.Should().Be("Summer holiday");
+    }
+
+    [Fact]
+    public async Task PausedChore_HasNoDeductionAtPeriodClose()
+    {
+        // Arrange - a daily required chore never completed over the whole period.
+        var household = await CreateHousehold("No Penalty Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Excused Kid");
+        await SetSalary(household.HouseholdId, kid.MemberId, baseSalary: 1000);
+
+        // Period the close will target: [prevPayday+1 .. today]. Start the chore
+        // well before that so every day in the period is a missed instance.
+        var choreId = await CreateDailyChore(household.HouseholdId, "Sweep Floor", startDaysAgo: 40, deduction: 10);
+        await AssignChore(household.HouseholdId, choreId, kid.MemberId);
+
+        // Pause the chore across a wide window covering the entire pay period.
+        await PauseChore(household.HouseholdId, choreId, DateTime.UtcNow.Date.AddDays(-40), DateTime.UtcNow.Date);
+
+        // Act - close the current period (ends today).
+        var close = await ClosePeriod(household.HouseholdId, DateTime.UtcNow.Date);
+
+        // Assert - the excused kid has no deductions for the paused chore.
+        var payout = close.Payouts.First(p => p.MemberId == kid.MemberId);
+        payout.Deductions.Should().Be(0);
+        payout.MissedChores.Should().NotContain(m => m.ChoreName == "Sweep Floor");
+        payout.NetPay.Should().Be(1000);
+    }
+
+    [Fact]
+    public async Task UnpausedChore_HasDeductionAtPeriodClose()
+    {
+        // Control: identical setup WITHOUT a pause produces deductions.
+        var household = await CreateHousehold("Penalty Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Slacker Kid");
+        await SetSalary(household.HouseholdId, kid.MemberId, baseSalary: 1000);
+
+        var choreId = await CreateDailyChore(household.HouseholdId, "Sweep Floor", startDaysAgo: 40, deduction: 10);
+        await AssignChore(household.HouseholdId, choreId, kid.MemberId);
+
+        var close = await ClosePeriod(household.HouseholdId, DateTime.UtcNow.Date);
+
+        var payout = close.Payouts.First(p => p.MemberId == kid.MemberId);
+        payout.Deductions.Should().BeGreaterThan(0);
+        payout.MissedChores.Should().Contain(m => m.ChoreName == "Sweep Floor");
+    }
+
+    #region Helpers
+
+    private async Task<Guid> CreateDailyChore(Guid householdId, string name, int startDaysAgo, decimal deduction = 10m)
+    {
+        var request = new
+        {
+            DisplayName = name,
+            Description = name,
+            Frequency = new { Type = "daily" },
+            StartDate = DateTime.UtcNow.AddDays(-startDaysAgo),
+            IsRequired = true,
+            MissedDeduction = deduction
+        };
+        var response = await _client.PostAsJsonAsync($"/api/households/{householdId}/chores", request);
+        response.EnsureSuccessStatusCode();
+
+        var chores = await _client.GetFromJsonAsync<GetChoresResponse>($"/api/households/{householdId}/chores");
+        return chores!.Chores.First(c => c.DisplayName == name).ChoreId;
+    }
+
+    private async Task AssignChore(Guid householdId, Guid choreId, Guid memberId)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{householdId}/chores/{choreId}/assign",
+            new { MemberIds = new[] { memberId }, AssignToAll = false });
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<Guid> PauseChore(Guid householdId, Guid choreId, DateTime start, DateTime end, string? reason = null)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{householdId}/chores/{choreId}/pause",
+            new { pauseStart = start, pauseEnd = end, pinCode = AdminPin, reason });
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<PauseChoreResponse>();
+        return result!.PauseId;
+    }
+
+    private async Task SetSalary(Guid householdId, Guid memberId, decimal baseSalary)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{householdId}/members/{memberId}/salary",
+            new { BaseSalary = baseSalary, DeductionMultiplier = 1.0m, BonusMultiplier = 1.0m });
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<ClosePeriodResponse> ClosePeriod(Guid householdId, DateTime periodEnd)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{householdId}/salary/close-period",
+            new { PeriodEnd = periodEnd });
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<ClosePeriodResponse>())!;
+    }
+
+    private async Task<CreateHouseholdResponse> CreateHousehold(string name)
+    {
+        var response = await _client.PostAsJsonAsync("/api/households", new { Name = name, PinCode = AdminPin });
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<CreateHouseholdResponse>())!;
+    }
+
+    private async Task<GenerateInviteResponse> GenerateInvite(Guid householdId)
+    {
+        var response = await _client.PostAsync($"/api/households/{householdId}/invite", null);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GenerateInviteResponse>())!;
+    }
+
+    private async Task<JoinHouseholdResponse> JoinHousehold(Guid householdId, Guid inviteId, string nickname)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/households/{householdId}/join",
+            new { InviteId = inviteId, Nickname = nickname });
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<JoinHouseholdResponse>())!;
+    }
+
+    private async Task<GetOverdueResponse> GetOverdueChores(Guid householdId)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/households/{householdId}/overdue");
+        request.Headers.Add("X-Pin-Code", AdminPin.ToString());
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<GetOverdueResponse>())!;
+    }
+
+    #endregion
+
+    #region Response Records
+
+    private record CreateHouseholdResponse(Guid HouseholdId, Guid MemberId, string Name);
+    private record GenerateInviteResponse(Guid HouseholdId, Guid InviteId, string Link);
+    private record JoinHouseholdResponse(Guid MemberId, Guid HouseholdId, string Nickname);
+    private record PauseChoreResponse(Guid PauseId);
+    private record GetChoresResponse(List<ChoreDto> Chores);
+    private record ChoreDto(Guid ChoreId, string DisplayName, List<PauseWindowDto>? Pauses);
+    private record PauseWindowDto(Guid PauseId, DateTime Start, DateTime End, string? Reason);
+    private record GetOverdueResponse(List<MemberOverdueDto> MemberOverdue);
+    private record MemberOverdueDto(Guid MemberId, string Nickname, int OverdueCount, List<OverdueChoreDto> Chores);
+    private record OverdueChoreDto(Guid ChoreId, string DisplayName, string OverduePeriod, DateTime? LastCompleted);
+    private record ClosePeriodResponse(Guid PeriodId, DateTime PeriodStart, DateTime PeriodEnd, List<PayoutSummaryDto> Payouts);
+    private record PayoutSummaryDto(Guid MemberId, string Name, decimal BaseSalary, decimal Deductions, decimal Bonuses, decimal NetPay, List<MissedChoreDto> MissedChores);
+    private record MissedChoreDto(Guid ChoreId, string ChoreName, string Period, decimal Deduction);
+
+    #endregion
+}

--- a/nestle-together/src/components/AddChoreDialog.tsx
+++ b/nestle-together/src/components/AddChoreDialog.tsx
@@ -23,7 +23,7 @@ import { Switch } from '@/components/ui/switch';
 import type { ChoreFrequency } from '@/types/household';
 
 interface AddChoreDialogProps {
-  onAdd: (displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number) => Promise<{ id: string } | null | void>;
+  onAdd: (displayName: string, description: string, frequency?: ChoreFrequency, isOptional?: boolean, startDate?: Date, isRequired?: boolean, missedDeduction?: number) => Promise<{ id: string } | null>;
   onSetRates?: (choreId: string, deductionRate: number, bonusRate: number) => Promise<void>;
 }
 

--- a/nestle-together/src/components/tabs/TeamTab.tsx
+++ b/nestle-together/src/components/tabs/TeamTab.tsx
@@ -3,6 +3,7 @@ import { InviteDialog } from '@/components/InviteDialog';
 import { RemoveMemberDialog } from '@/components/RemoveMemberDialog';
 import { TeamOverviewAccordion } from '@/components/TeamOverviewAccordion';
 import type { Member } from '@/features/members/types';
+import type { Invite } from '@/types/household';
 
 // Marquee for member status
 function StatusMarquee({ text }: { text: string }) {
@@ -28,7 +29,7 @@ interface TeamTabProps {
   refreshKey: number;
   hoveredMemberStatus: string | null;
   onHoverStatus: (status: string | null) => void;
-  onGenerateInvite: () => ReturnType<typeof Promise.resolve>;
+  onGenerateInvite: () => Promise<Invite | null>;
   onRemoveMember: (memberId: string, pinCode: string) => Promise<boolean>;
   onAssignmentChange: () => void;
 }

--- a/nestle-together/src/features/admin/components/ChoreManagement.css
+++ b/nestle-together/src/features/admin/components/ChoreManagement.css
@@ -75,6 +75,51 @@
   color: var(--primary, #4CAF50);
 }
 
+.pause-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.125rem;
+}
+
+.pause-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 999px;
+  background: #eceff1;
+  color: var(--text-muted, #607d8b);
+}
+
+.pause-badge.active {
+  background: #fff3e0;
+  color: #e65100;
+  font-weight: 600;
+}
+
+.pause-badge .pause-remove {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.6;
+}
+
+.pause-badge .pause-remove:hover {
+  opacity: 1;
+}
+
+.pause-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted, #666);
+  margin: 0 0 0.25rem;
+}
+
 .chore-actions {
   display: flex;
   gap: 0.25rem;

--- a/nestle-together/src/features/admin/components/ChoreManagement.tsx
+++ b/nestle-together/src/features/admin/components/ChoreManagement.tsx
@@ -1,10 +1,25 @@
 import { useState, useEffect } from 'react';
-import { Trash2, Users, DollarSign, Star, Pencil } from 'lucide-react';
+import { Trash2, Users, DollarSign, Star, Pencil, CalendarClock, X } from 'lucide-react';
 import { useHouseholdStore } from '@/stores/householdStore';
 import { setChoreRates } from '../../salary/api';
-import { updateChore } from '../../chores/api';
-import type { Chore } from '../../chores/types';
+import { updateChore, pauseChore, removeChorePause } from '../../chores/api';
+import type { Chore, PauseWindow } from '../../chores/types';
 import './ChoreManagement.css';
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatPauseRange(p: PauseWindow): string {
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
+  return `${p.start.toLocaleDateString(undefined, opts)} – ${p.end.toLocaleDateString(undefined, opts)}`;
+}
+
+function isPauseActive(p: PauseWindow): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return p.start <= today && today <= p.end;
+}
 
 interface EditForm {
   displayName: string;
@@ -37,6 +52,9 @@ export function ChoreManagement() {
   });
   const [editSaving, setEditSaving] = useState(false);
   const [assigningChore, setAssigningChore] = useState<string | null>(null);
+  const [pausingChore, setPausingChore] = useState<string | null>(null);
+  const [pauseForm, setPauseForm] = useState({ start: todayIso(), end: todayIso(), reason: '' });
+  const [pauseSaving, setPauseSaving] = useState(false);
   const [ratesForm, setRatesForm] = useState({ deductionRate: '10', bonusRate: '10' });
   const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
   const [assignToAll, setAssignToAll] = useState(false);
@@ -143,6 +161,43 @@ export function ChoreManagement() {
     setAssigningChore(chore.id);
     setSelectedMembers(chore.assignedTo || []);
     setAssignToAll(chore.assignedToAll || false);
+  }
+
+  function startPausing(chore: Chore) {
+    setPausingChore(chore.id);
+    setPauseForm({ start: todayIso(), end: todayIso(), reason: '' });
+  }
+
+  async function savePause(chore: Chore) {
+    if (!currentHouseholdId || !currentPinCode) return;
+    if (pauseForm.end < pauseForm.start) {
+      showMessage('End date must be on or after start date');
+      return;
+    }
+    setPauseSaving(true);
+    const result = await pauseChore(currentHouseholdId, chore.id, {
+      pauseStart: pauseForm.start,
+      pauseEnd: pauseForm.end,
+      pinCode: Number(currentPinCode),
+      reason: pauseForm.reason.trim() || undefined,
+    });
+    if (result) {
+      setPausingChore(null);
+      showMessage('Chore paused');
+      loadData();
+    } else {
+      showMessage('Could not pause chore');
+    }
+    setPauseSaving(false);
+  }
+
+  async function handleRemovePause(choreId: string, pauseId: string) {
+    if (!currentHouseholdId || !currentPinCode) return;
+    const ok = await removeChorePause(currentHouseholdId, choreId, pauseId, Number(currentPinCode));
+    if (ok) {
+      showMessage('Pause removed');
+      loadData();
+    }
   }
 
   function showMessage(text: string) {
@@ -279,6 +334,29 @@ export function ChoreManagement() {
                   <button className="save-btn" onClick={() => handleSaveAssignment(chore.id)}>💾 Save</button>
                 </div>
               </div>
+            ) : pausingChore === chore.id ? (
+              <div className="edit-form">
+                <h4>Pause “{chore.displayName}”</h4>
+                <p className="pause-hint">Missed instances between these dates won't count as overdue or deduct pay.</p>
+                <label>From
+                  <input type="date" value={pauseForm.start}
+                    onChange={e => setPauseForm({ ...pauseForm, start: e.target.value })} />
+                </label>
+                <label>To
+                  <input type="date" value={pauseForm.end} min={pauseForm.start}
+                    onChange={e => setPauseForm({ ...pauseForm, end: e.target.value })} />
+                </label>
+                <label>Reason (optional)
+                  <input type="text" placeholder="e.g. Summer holiday" value={pauseForm.reason}
+                    onChange={e => setPauseForm({ ...pauseForm, reason: e.target.value })} />
+                </label>
+                <div className="form-actions">
+                  <button className="cancel-btn" onClick={() => setPausingChore(null)}>Cancel</button>
+                  <button className="save-btn" disabled={pauseSaving} onClick={() => savePause(chore)}>
+                    {pauseSaving ? 'Saving...' : '⏸ Pause'}
+                  </button>
+                </div>
+              </div>
             ) : (
               <>
                 <div className="chore-info">
@@ -288,9 +366,24 @@ export function ChoreManagement() {
                     {(chore.deductionRate ?? chore.missedDeduction) ? ` • -${chore.deductionRate ?? chore.missedDeduction} kr` : ''}
                   </span>
                   <span className="assigned">
-                    {chore.assignedToAll ? 'Everyone' : 
+                    {chore.assignedToAll ? 'Everyone' :
                       chore.assignedTo?.length ? `${chore.assignedTo.length} assigned` : 'Unassigned'}
                   </span>
+                  {chore.pauses && chore.pauses.length > 0 && (
+                    <div className="pause-badges">
+                      {chore.pauses.map(p => (
+                        <span key={p.pauseId} className={`pause-badge${isPauseActive(p) ? ' active' : ''}`}
+                          title={p.reason || undefined}>
+                          <CalendarClock className="w-3 h-3" />
+                          {isPauseActive(p) ? 'Paused' : 'Pause'} {formatPauseRange(p)}
+                          <button className="pause-remove" title="Remove pause"
+                            onClick={() => handleRemovePause(chore.id, p.pauseId)}>
+                            <X className="w-3 h-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 <div className="chore-actions">
                   <button onClick={() => startEditingDetails(chore)} title="Edit chore">
@@ -298,6 +391,9 @@ export function ChoreManagement() {
                   </button>
                   <button onClick={() => startAssigning(chore)} title="Assign">
                     <Users className="w-4 h-4" />
+                  </button>
+                  <button onClick={() => startPausing(chore)} title="Pause chore">
+                    <CalendarClock className="w-4 h-4" />
                   </button>
                   <button onClick={() => startEditing(chore)} title="Edit rates">
                     <DollarSign className="w-4 h-4" />

--- a/nestle-together/src/features/chores/api.ts
+++ b/nestle-together/src/features/chores/api.ts
@@ -7,6 +7,7 @@ import type {
   MemberOverdue,
   ChoreFrequency,
   MemberCompletion,
+  PauseWindow,
 } from './types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://localhost:7422';
@@ -48,6 +49,14 @@ export async function fetchChores(householdId: string): Promise<Chore[]> {
       missedDeduction: c.missedDeduction as number | undefined,
       deductionRate: c.deductionRate as number | undefined,
       bonusRate: c.bonusRate as number | undefined,
+      pauses: Array.isArray(c.pauses)
+        ? (c.pauses as Record<string, unknown>[]).map((p) => ({
+            pauseId: p.pauseId as string,
+            start: new Date(p.start as string),
+            end: new Date(p.end as string),
+            reason: (p.reason ?? undefined) as string | undefined,
+          }))
+        : undefined,
     };
   });
 }
@@ -238,6 +247,59 @@ export async function updateChore(
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
+    }
+  );
+  return response.ok;
+}
+
+// ============ Pause Chore ============
+
+export interface PauseChorePayload {
+  pauseStart: string; // ISO date
+  pauseEnd: string;   // ISO date
+  pinCode: number;
+  reason?: string;
+}
+
+/** Adds a pause window to a chore. Returns the new pause window on success. */
+export async function pauseChore(
+  householdId: string,
+  choreId: string,
+  payload: PauseChorePayload
+): Promise<PauseWindow | null> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/households/${householdId}/chores/${choreId}/pause`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }
+  );
+  if (!response.ok) {
+    return null;
+  }
+  const data = await response.json();
+  return {
+    pauseId: data.pauseId as string,
+    start: new Date(payload.pauseStart),
+    end: new Date(payload.pauseEnd),
+    reason: payload.reason,
+  };
+}
+
+/** Removes a pause window from a chore by its pauseId. */
+export async function removeChorePause(
+  householdId: string,
+  choreId: string,
+  pauseId: string,
+  pinCode: number
+): Promise<boolean> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/households/${householdId}/chores/${choreId}/pause/${pauseId}/remove`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pinCode }),
     }
   );
   return response.ok;

--- a/nestle-together/src/features/chores/types.ts
+++ b/nestle-together/src/features/chores/types.ts
@@ -12,6 +12,15 @@ export interface MemberCompletion {
   lastCompletedAt?: Date;
 }
 
+// A date range during which the chore's missed instances are exempt from
+// overdue status and salary deductions.
+export interface PauseWindow {
+  pauseId: string;
+  start: Date;
+  end: Date;
+  reason?: string;
+}
+
 export interface Chore {
   id: string;
   householdId: string;
@@ -30,6 +39,7 @@ export interface Chore {
   missedDeduction?: number;
   deductionRate?: number;
   bonusRate?: number;
+  pauses?: PauseWindow[];
 }
 
 export interface ChoreCompletion {


### PR DESCRIPTION
## What

Adds a **pause chore** feature: a chore can be paused for a start/end date window. Any missed instances that fall within an active pause window are **exempt** — they don't show as overdue in the live views, and they incur **no salary deduction** when the pay period is closed. This is the feature requested: "if we have a start and end date, any missed instances of that chore within the time period doesn't result in a penalty."

## Design decisions (confirmed with product owner)

- **Multiple pause windows per chore** — each is its own event (`ChorePaused`) keyed by `PauseId`, removable independently via `ChorePauseRemoved`. Vacation + a sick week can coexist.
- **Exempt everywhere** — not just the salary penalty at period-close, but also the live "overdue" surfaces, for consistency.
- **Dedicated Pause button** on each required chore in the admin panel (kept the add/edit form clean).
- **Admin-gated** — pausing affects pay, so both commands require the admin PIN (same pattern as delete).

## Backend (event-sourced, `chores-{householdId}` stream)

- New events `ChorePaused` / `ChorePauseRemoved`.
- New vertical-slice commands `PauseChore` / `RemoveChorePause` (endpoints under `/chores/{id}/pause`).
- Shared `ChorePauses` domain helper builds the active windows (honoring removals) and exposes `CoversDate` / `CoversAnyInRange`.
- Exemption threaded into **all four** "missed" computation sites so behavior can't drift: `ClosePeriod` (the penalty), `OverdueChores`, `TeamOverview`, `MyChores`.
- `ChoreList` returns active pause windows so the UI can render them.

## Frontend (`nestle-together`)

- Pause action + inline date-range form on required chores in **Chore Management**, with active/upcoming pause **badges** (click × to remove).
- `chores/api.ts`: `pauseChore` / `removeChorePause` + `pauses` mapping in `fetchChores`; `PauseWindow` type added. (Kept in the existing per-feature `api.ts` to match the rest of this frontend — a per-slice migration would be its own PR.)

## Testing

- New `ChorePauseTests`: overdue exemption, **penalty exemption at period close with an unpaused control**, pause removal restoring overdue, auth (403) + validation (400), and the `ChoreList` window surface.
- **Full integration suite: 101 passing, 0 failing.**
- Frontend `tsc -b` introduces zero new type errors (two pre-existing errors in `AddChoreDialog.tsx` / `TeamTab.tsx` are unrelated and present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)