### PR TITLE
fix(salary): honor chore pauses in the live current-period preview

### DIFF
--- a/ChoreMonkey.Core/Feature/Salary/Queries/GetCurrentPeriod/Handler.cs
+++ b/ChoreMonkey.Core/Feature/Salary/Queries/GetCurrentPeriod/Handler.cs
@@ -92,6 +92,9 @@ internal class Handler(IEventStore store, ISender mediator)
             .GroupBy(e => e.ChoreId)
             .ToDictionary(g => g.Key, g => g.Last());
 
+        // Active pause windows per chore — missed instances within a window are exempt.
+        var chorePauses = ChorePauses.Build(choreEvents);
+
         // Get completions in period grouped by (chore, member)
         var completionsInPeriod = choreEvents
             .OfType<ChoreCompleted>()
@@ -155,11 +158,12 @@ internal class Handler(IEventStore store, ISender mediator)
                 {
                     // Required chores: check for missed instances (>2 days overdue)
                     var missed = CalculateMissedInstances(
-                        chore, 
-                        lastCompletion?.CompletedAt, 
-                        periodStart, 
+                        chore,
+                        lastCompletion?.CompletedAt,
+                        periodStart,
                         today,
-                        completionsInPeriod.GetValueOrDefault((choreId, memberId)));
+                        completionsInPeriod.GetValueOrDefault((choreId, memberId)),
+                        chorePauses.GetValueOrDefault(choreId));
                     
                     var deductionRate = rates?.DeductionRate ?? chore.MissedDeduction;
                     foreach (var period in missed)
@@ -208,11 +212,12 @@ internal class Handler(IEventStore store, ISender mediator)
     }
 
     private List<string> CalculateMissedInstances(
-        ChoreCreated chore, 
-        DateTime? lastCompleted, 
+        ChoreCreated chore,
+        DateTime? lastCompleted,
         DateTime periodStart,
         DateTime today,
-        List<ChoreCompleted>? completionsInPeriod)
+        List<ChoreCompleted>? completionsInPeriod,
+        List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var frequency = chore.Frequency;
@@ -220,34 +225,34 @@ internal class Handler(IEventStore store, ISender mediator)
 
         var choreStart = chore.StartDate?.Date ?? periodStart;
         var effectiveStart = choreStart > periodStart ? choreStart : periodStart;
-        
+
         // Only count as missed if grace period has passed
         var cutoffDate = today.AddDays(-GracePeriodDays);
 
         switch (frequency.Type.ToLower())
         {
             case "daily":
-                missed = CalculateDailyMissed(effectiveStart, cutoffDate, completionsInPeriod);
+                missed = CalculateDailyMissed(effectiveStart, cutoffDate, completionsInPeriod, pauses);
                 break;
             case "weekly":
-                missed = CalculateWeeklyMissed(frequency.Days, effectiveStart, cutoffDate, completionsInPeriod);
+                missed = CalculateWeeklyMissed(frequency.Days, effectiveStart, cutoffDate, completionsInPeriod, pauses);
                 break;
             case "interval":
-                missed = CalculateIntervalMissed(frequency.IntervalDays ?? 1, effectiveStart, cutoffDate, lastCompleted, completionsInPeriod);
+                missed = CalculateIntervalMissed(frequency.IntervalDays ?? 1, effectiveStart, cutoffDate, lastCompleted, completionsInPeriod, pauses);
                 break;
         }
 
         return missed;
     }
 
-    private static List<string> CalculateDailyMissed(DateTime start, DateTime cutoff, List<ChoreCompleted>? completions)
+    private static List<string> CalculateDailyMissed(DateTime start, DateTime cutoff, List<ChoreCompleted>? completions, List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var completedDates = completions?.Select(c => c.CompletedAt.Date).ToHashSet() ?? new HashSet<DateTime>();
-        
+
         for (var date = start; date <= cutoff; date = date.AddDays(1))
         {
-            if (!completedDates.Contains(date))
+            if (!completedDates.Contains(date) && !pauses.CoversDate(date))
             {
                 missed.Add(date.ToString("yyyy-MM-dd"));
             }
@@ -261,7 +266,7 @@ internal class Handler(IEventStore store, ISender mediator)
         return date.AddDays(-diff).Date;
     }
 
-    private static List<string> CalculateWeeklyMissed(string[]? days, DateTime start, DateTime cutoff, List<ChoreCompleted>? completions)
+    private static List<string> CalculateWeeklyMissed(string[]? days, DateTime start, DateTime cutoff, List<ChoreCompleted>? completions, List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var completedDates = completions?.Select(c => c.CompletedAt.Date).ToHashSet() ?? new HashSet<DateTime>();
@@ -271,13 +276,15 @@ internal class Handler(IEventStore store, ISender mediator)
             // Weekly anytime - one completion per week required
             var currentWeek = GetMondayOfWeek(start);
             var cutoffWeek = GetMondayOfWeek(cutoff);
-            
+
             while (currentWeek <= cutoffWeek)
             {
                 var weekEnd = currentWeek.AddDays(6);
                 var completedThisWeek = completedDates.Any(d => d >= currentWeek && d <= weekEnd);
-                
-                if (!completedThisWeek && weekEnd <= cutoff)
+                // Exempt the week if a pause window overlaps any day of it.
+                var pausedThisWeek = pauses.CoversAnyInRange(currentWeek, weekEnd);
+
+                if (!completedThisWeek && !pausedThisWeek && weekEnd <= cutoff)
                 {
                     var weekNum = System.Globalization.CultureInfo.InvariantCulture.Calendar
                         .GetWeekOfYear(currentWeek, System.Globalization.CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
@@ -290,32 +297,32 @@ internal class Handler(IEventStore store, ISender mediator)
         {
             // Specific days required
             var requiredDays = days.Select(d => Enum.Parse<DayOfWeek>(d, ignoreCase: true)).ToHashSet();
-            
+
             for (var date = start; date <= cutoff; date = date.AddDays(1))
             {
-                if (requiredDays.Contains(date.DayOfWeek) && !completedDates.Contains(date))
+                if (requiredDays.Contains(date.DayOfWeek) && !completedDates.Contains(date) && !pauses.CoversDate(date))
                 {
                     missed.Add(date.ToString("yyyy-MM-dd"));
                 }
             }
         }
-        
+
         return missed;
     }
 
-    private static List<string> CalculateIntervalMissed(int intervalDays, DateTime start, DateTime cutoff, DateTime? lastCompleted, List<ChoreCompleted>? completions)
+    private static List<string> CalculateIntervalMissed(int intervalDays, DateTime start, DateTime cutoff, DateTime? lastCompleted, List<ChoreCompleted>? completions, List<PauseWindow>? pauses)
     {
         var missed = new List<string>();
         var completedDates = completions?.Select(c => c.CompletedAt.Date).OrderBy(d => d).ToList() ?? new List<DateTime>();
-        
+
         var lastDue = lastCompleted?.Date ?? start.AddDays(-1);
         var idx = 0;
-        
+
         while (true)
         {
             var nextDue = lastDue.AddDays(intervalDays);
             if (nextDue > cutoff) break;
-            
+
             // Check if completed on or before next due date
             while (idx < completedDates.Count && completedDates[idx] <= nextDue)
             {
@@ -324,14 +331,18 @@ internal class Handler(IEventStore store, ISender mediator)
                 nextDue = lastDue.AddDays(intervalDays);
                 if (nextDue > cutoff) break;
             }
-            
+
             if (nextDue > cutoff) break;
-            
-            // Not completed - it's missed
-            missed.Add(nextDue.ToString("yyyy-MM-dd"));
+
+            // Advance the schedule regardless, but only record a miss when the
+            // due date isn't within a pause window.
+            if (!pauses.CoversDate(nextDue))
+            {
+                missed.Add(nextDue.ToString("yyyy-MM-dd"));
+            }
             lastDue = nextDue;
         }
-        
+
         return missed;
     }
 }

--- a/ChoreMonkey.IntegrationTests/Chores/ChorePauseTests.cs
+++ b/ChoreMonkey.IntegrationTests/Chores/ChorePauseTests.cs
@@ -153,7 +153,40 @@ public class ChorePauseTests(ApiFixture fixture)
         payout.MissedChores.Should().Contain(m => m.ChoreName == "Sweep Floor");
     }
 
+    [Fact]
+    public async Task PausedChore_HasNoDeductionInCurrentPeriodPreview()
+    {
+        // The live salary preview (GET /salary/current) must also honor pauses.
+        var household = await CreateHousehold("Preview Excused Family");
+        var invite = await GenerateInvite(household.HouseholdId);
+        var kid = await JoinHousehold(household.HouseholdId, invite.InviteId, "Excused Kid");
+        await SetSalary(household.HouseholdId, kid.MemberId, baseSalary: 1000);
+
+        var choreId = await CreateDailyChore(household.HouseholdId, "Sweep Floor", startDaysAgo: 40, deduction: 10);
+        await AssignChore(household.HouseholdId, choreId, kid.MemberId);
+
+        // Sanity: without a pause the preview shows deductions
+        var before = await GetCurrentPeriod(household.HouseholdId);
+        before.Members.First(m => m.MemberId == kid.MemberId).Deductions.Should().BeGreaterThan(0);
+
+        // Pause across the whole current period
+        await PauseChore(household.HouseholdId, choreId, DateTime.UtcNow.Date.AddDays(-40), DateTime.UtcNow.Date);
+
+        var after = await GetCurrentPeriod(household.HouseholdId);
+        var summary = after.Members.First(m => m.MemberId == kid.MemberId);
+        summary.Deductions.Should().Be(0);
+        summary.MissedChores.Should().NotContain(m => m.ChoreName == "Sweep Floor");
+        summary.Projected.Should().Be(1000);
+    }
+
     #region Helpers
+
+    private async Task<CurrentPeriodResponse> GetCurrentPeriod(Guid householdId)
+    {
+        var response = await _client.GetAsync($"/api/households/{householdId}/salary/current");
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<CurrentPeriodResponse>())!;
+    }
 
     private async Task<Guid> CreateDailyChore(Guid householdId, string name, int startDaysAgo, decimal deduction = 10m)
     {
@@ -257,6 +290,8 @@ public class ChorePauseTests(ApiFixture fixture)
     private record ClosePeriodResponse(Guid PeriodId, DateTime PeriodStart, DateTime PeriodEnd, List<PayoutSummaryDto> Payouts);
     private record PayoutSummaryDto(Guid MemberId, string Name, decimal BaseSalary, decimal Deductions, decimal Bonuses, decimal NetPay, List<MissedChoreDto> MissedChores);
     private record MissedChoreDto(Guid ChoreId, string ChoreName, string Period, decimal Deduction);
+    private record CurrentPeriodResponse(DateTime PeriodStart, DateTime PeriodEnd, List<MemberPeriodSummary> Members);
+    private record MemberPeriodSummary(Guid MemberId, string Name, decimal BaseSalary, decimal Deductions, decimal Bonuses, decimal Projected, List<MissedChoreDto> MissedChores);
 
     #endregion
 }


### PR DESCRIPTION
## Why

Follow-up to #54. The salary **preview** (`GET /salary/current`, shown in `MyAllowance` and `SalaryAdmin`) has its *own* copy of the missed-instance calculation — a fifth live "missed" site that #54 didn't wire for pauses. So a paused chore still showed **projected deductions** in the preview, even though `ClosePeriod` correctly exempts them. This surfaced when testing a pause against the current period.

## Fix

Thread active pause windows (`ChorePauses.Build`) through `GetCurrentPeriod`'s `CalculateMissedInstances` and its daily/weekly/interval calculators — same exemption already applied in `ClosePeriod` / `OverdueChores` / `TeamOverview` / `MyChores`. All five live computation sites now agree.

## Read-model note (answers the original question)

There are **no materialized read models** to rebuild — every salary view is computed on-demand by replaying the event stream per request, so the preview reflects a new pause on the next fetch (SignalR already invalidates the client cache). No "retrigger" needed.

**Already-closed periods are the exception:** `ClosePeriod` bakes deductions into an immutable `PeriodClosed` event that the slip/history read verbatim, and an `alreadyClosed` guard blocks re-closing. A pause added *after* a period closes will **not** retroactively change that period — that would need a dedicated reopen/recompute path, which doesn't exist today and is left out of scope here.

## Testing

- New `PausedChore_HasNoDeductionInCurrentPeriodPreview` (asserts the preview deducts *before* the pause and not *after*).
- Full integration suite: **102 passing, 0 failing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)